### PR TITLE
Properly maintain role separation for service exposal by merging CMs.

### DIFF
--- a/control-plane/roles/metal/tasks/main.yaml
+++ b/control-plane/roles/metal/tasks/main.yaml
@@ -27,6 +27,14 @@
     helm_timeout: 600s
     helm_chart_inject_config_hash: yes
 
+- name: Set services for patching ingress controller service exposal
+  set_fact:
+    metal_tcp_services:
+      "5222": "{{ metal_control_plane_namespace }}/metal-console:10001"
+    metal_udp_services:
+      "5222": "{{ metal_control_plane_namespace }}/metal-console:10001"
+  when: metal_expose_ingress_service_ports
+
 - name: Patch tcp-services in ingress controller
   k8s:
     api_version: v1
@@ -34,10 +42,7 @@
     namespace: ingress-nginx
     name: tcp-services
     definition:
-      data:
-        4161: "{{ metal_control_plane_namespace }}/nsq-lookupd:4161"
-        4150: "{{ metal_control_plane_namespace }}/nsqd:4150"
-        5222: "{{ metal_control_plane_namespace }}/metal-console:10001"
+      data: "{{ lookup('k8s', api_version='v1', kind='ConfigMap', namespace='ingress-nginx', resource_name='tcp-services').get('data', {}) | combine(metal_tcp_services) }}"
   when: metal_expose_ingress_service_ports
 
 - name: Patch udp-services in ingress controller
@@ -47,8 +52,7 @@
     namespace: ingress-nginx
     name: udp-services
     definition:
-      data:
-        5222: "{{ metal_control_plane_namespace }}/metal-console:10001"
+      data: "{{ lookup('k8s', api_version='v1', kind='ConfigMap', namespace='ingress-nginx', resource_name='udp-services').get('data', {}) | combine(metal_udp_services) }}"
   when: metal_expose_ingress_service_ports
 
 - name: Expose tcp services in ingress controller
@@ -60,20 +64,6 @@
     definition:
       spec:
         ports:
-        - name: http
-          port: 80
-          targetPort: http
-        - name: https
-          port: 443
-          targetPort: https
-        - name: nsq-lookupd
-          port: 4161
-          protocol: TCP
-          targetPort: 4161
-        - name: nsqd
-          port: 4150
-          protocol: TCP
-          targetPort: 4150
         - name: metal-control-plane-console
           port: 5222
           protocol: TCP

--- a/control-plane/roles/nsq/tasks/main.yaml
+++ b/control-plane/roles/nsq/tasks/main.yaml
@@ -3,3 +3,39 @@
   k8s:
     definition: "{{ lookup('template', 'nsq.yaml') }}"
     namespace: "{{ metal_control_plane_namespace }}"
+
+- name: Set services for patching ingress controller service exposal
+  set_fact:
+    nsq_tcp_services:
+      "4161": "{{ metal_control_plane_namespace }}/nsq-lookupd:4161"
+      "4150": "{{ metal_control_plane_namespace }}/nsqd:4150"
+  when: nsq_expose_ingress_service_ports
+
+- name: Patch tcp-services in ingress controller
+  k8s:
+    api_version: v1
+    kind: ConfigMap
+    namespace: ingress-nginx
+    name: tcp-services
+    definition:
+      data: "{{ lookup('k8s', api_version='v1', kind='ConfigMap', namespace='ingress-nginx', resource_name='tcp-services').get('data', {}) | combine(nsq_tcp_services) }}"
+  when: nsq_expose_ingress_service_ports
+
+- name: Expose tcp services in ingress controller
+  k8s:
+    api_version: v1
+    kind: Service
+    namespace: ingress-nginx
+    name: ingress-nginx
+    definition:
+      spec:
+        ports:
+        - name: nsq-lookupd
+          port: 4161
+          protocol: TCP
+          targetPort: 4161
+        - name: nsqd
+          port: 4150
+          protocol: TCP
+          targetPort: 4150
+  when: nsq_expose_ingress_service_ports


### PR DESCRIPTION
We did not find a way to expose services from the individual roles in the past and put everything into the metal role. It's not that hard to do this from individual roles though by using the `combine` filter from ansible.