### PR TITLE
Make resources for components in metal-control-plane variable and adjust resources a little.

### DIFF
--- a/control-plane/roles/metal/README.md
+++ b/control-plane/roles/metal/README.md
@@ -74,6 +74,7 @@ You can look up all the default values of this role [here](defaults/main/main.ya
 | metal_api_partitions          |           | Creates partitions (as masterdata) to the metal-api after deployment |
 | metal_api_networks            |           | Creates networks (as masterdata) to the metal-api after deployment   |
 | metal_api_ips                 |           | Creates ips (as masterdata) to the metal-api after deployment        |
+| metal_api_resources           |           | Sets the given container resources                                   |
 
 ### masterdata-api
 
@@ -93,13 +94,15 @@ You can look up all the default values of this role [here](defaults/main/main.ya
 | metal_masterdata_api_hmac            |           | The HMAC key of the masterdata-api used for API technical access |
 | metal_masterdata_api_tenants         |           | Starts up the masterdata-api with given list of tenants          |
 | metal_masterdata_api_projects        |           | Starts up the masterdata-api with the given list of projects     |
+| metal_masterdata_api_resources       |           | Sets the given container resources                               |
 
 # metal-console
 
-| Name                   | Mandatory | Description                                                                                                 |
-| ---------------------- | --------- | ----------------------------------------------------------------------------------------------------------- |
-| metal_console_replicas |           | The number of deployed replicas of the metal-console                                                        |
-| metal_mgmt_services    |           | Endpoints to reverse bmc-proxies located inside the partitions for establishing machine console connections |
+| Name                    | Mandatory | Description                                                                                                 |
+| ----------------------- | --------- | ----------------------------------------------------------------------------------------------------------- |
+| metal_console_replicas  |           | The number of deployed replicas of the metal-console                                                        |
+| metal_mgmt_services     |           | Endpoints to reverse bmc-proxies located inside the partitions for establishing machine console connections |
+| metal_console_resources |           | Sets the given container resources                                                                          |
 
 # Ingress
 

--- a/control-plane/roles/metal/defaults/main/main.yaml
+++ b/control-plane/roles/metal/defaults/main/main.yaml
@@ -46,6 +46,7 @@ metal_api_images: []
 metal_api_partitions: []
 metal_api_networks: []
 metal_api_ips: []
+metal_api_resources:
 
 # masterdata-api
 metal_masterdata_api_db_address: masterdata-db
@@ -55,12 +56,15 @@ metal_masterdata_api_db_user: postgres
 metal_masterdata_api_db_password: change-me
 metal_masterdata_api_provider_tenant: "{{ metal_control_plane_provider_tenant }}"
 metal_masterdata_api_hmac: change-me
+metal_masterdata_api_resources:
 
 metal_masterdata_api_tenants: []
 metal_masterdata_api_projects: []
 
 # metal-console
 metal_console_replicas: 3
+metal_console_resources:
+
 metal_mgmt_services: {}
 # expected metal_mgmt_services data structure looks like this:
 # metal_mgmt_services:

--- a/control-plane/roles/metal/files/metal-control-plane/values.yaml
+++ b/control-plane/roles/metal/files/metal-control-plane/values.yaml
@@ -36,10 +36,10 @@ resources:
   metal_console:
     requests:
       memory: "64Mi"
-      cpu: "20m"
+      cpu: "40m"
     limits:
       memory: "128Mi"
-      cpu: "30m"
+      cpu: "60m"
 
 ports:
   metal_api: 8080

--- a/control-plane/roles/metal/templates/metal-values.j2
+++ b/control-plane/roles/metal/templates/metal-values.j2
@@ -18,6 +18,17 @@ images:
     image: "{{ metal_masterdata_api_image_name }}"
     tag: "{{ metal_masterdata_api_image_tag }}"
 
+resources:
+{% if metal_api_resources %}
+  metal_api: {{ metal_api_resources | to_json }}
+{% endif %}
+{% if metal_masterdata_api_resources %}
+  masterdata_api: {{ metal_masterdata_api_resources | to_json }}
+{% endif %}
+{% if metal_console_resources %}
+  metal_console: {{ metal_console_resources | to_json }}
+{% endif %}
+
 metal_console:
   replicas: "{{ metal_console_replicas }}"
 

--- a/control-plane/roles/nsq/defaults/main/main.yaml
+++ b/control-plane/roles/nsq/defaults/main/main.yaml
@@ -15,10 +15,10 @@ nsq_nsqd_resources:
 nsq_nsq_lookupd_resources:
   requests:
     memory: "8Mi"
-    cpu: "10m"
+    cpu: "20m"
   limits:
     memory: "16Mi"
-    cpu: "20m"
+    cpu: "40m"
 
 nsq_log_level: info
 nsq_broadcast_address: "{{ metal_control_plane_ingress_dns }}"


### PR DESCRIPTION
Makes resources in control-plane variable and increases nsqlookupd and metal-console resources a bit because they were pretty low and are throttled regularly.