### PR TITLE
Adding metrics port to backup-restore-sidecar.

### DIFF
--- a/control-plane/roles/postgres-backup-restore/templates/postgres.yaml
+++ b/control-plane/roles/postgres-backup-restore/templates/postgres.yaml
@@ -77,7 +77,9 @@ spec:
         args:
         - sh
         - -c
-        - mkdir -p /data/postgres && backup-restore-sidecar start --log-level debug
+        - mkdir -p /data/postgres && backup-restore-sidecar start
+        ports:
+        - containerPort: 2112
         env:
         - name: BACKUP_RESTORE_SIDECAR_POSTGRES_PASSWORD
           valueFrom:
@@ -207,6 +209,9 @@ metadata:
   name: {{ postgres_name }}
 spec:
   ports:
+  - name: "metrics"
+    port: 2112
+    targetPort: 2112
   - name: "5432"
     port: 5432
     targetPort: 5432

--- a/control-plane/roles/rethinkdb-backup-restore/templates/rethinkdb.yaml
+++ b/control-plane/roles/rethinkdb-backup-restore/templates/rethinkdb.yaml
@@ -56,7 +56,9 @@ spec:
         args:
         - sh
         - -c
-        - mkdir -p /data/rethinkdb && backup-restore-sidecar start --log-level debug
+        - mkdir -p /data/rethinkdb && backup-restore-sidecar start
+        ports:
+        - containerPort: 2112
         env:
 {% if rethinkdb_backup_restore_sidecar_provider == "gcp" %}
         - name: BACKUP_RESTORE_SIDECAR_GCP_PROJECT
@@ -179,6 +181,9 @@ metadata:
   name: {{ rethinkdb_name }}
 spec:
   ports:
+  - name: "metrics"
+    port: 2112
+    targetPort: 2112
   - name: "10080"
     port: 10080
     targetPort: 8080


### PR DESCRIPTION
References https://github.com/metal-stack/backup-restore-sidecar/pull/15.

Also removed the `--log-level` option because this is being picked up from the config file anyway.