### PR TITLE
bmc-proxy-endpoints are now external name services.

### DIFF
--- a/control-plane/roles/metal/README.md
+++ b/control-plane/roles/metal/README.md
@@ -46,7 +46,6 @@ You can look up all the default values of this role [here](defaults/main/main.ya
 | metal_masterdata_api_port         |           | Service port of the masterdata-api                |
 | metal_masterdata_api_metrics_port |           | Service port of the masterdata-api metrics server |
 | metal_console_port                |           | Service port of the metal-console                 |
-| metal_bmc_reverse_proxy_port      |           | Service port of the bmc reverse proxy             |
 
 ### metal-api
 
@@ -103,16 +102,16 @@ You can look up all the default values of this role [here](defaults/main/main.ya
 
 # metal-console
 
-| Name                                      | Mandatory | Description                                                                                                 |
-| ----------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------- |
-| metal_console_replicas                    |           | The number of deployed replicas of the metal-console                                                        |
-| metal_mgmt_services                       |           | Endpoints to reverse bmc-proxies located inside the partitions for establishing machine console connections |
-| metal_console_resources                   |           | Sets the given container resources                                                                          |
-| metal_console_bmc_proxy_certs_ca_cert     | yes       | The bmc-proxy ca certificate as a string                                                                    |
-| metal_console_bmc_proxy_certs_server_key  | yes       | The bmc-proxy server key as a string                                                                        |
-| metal_console_bmc_proxy_certs_server_pub  | yes       | The bmc-proxy server public key as a string                                                                 |
-| metal_console_bmc_proxy_certs_client_cert | yes       | The bmc-proxy client certificate as a string                                                                |
-| metal_console_bmc_proxy_certs_client_key  | yes       | The bmc-proxy client key as a string                                                                        |
+| Name                                      | Mandatory | Description                                                                                                                        |
+| ----------------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| metal_console_replicas                    |           | The number of deployed replicas of the metal-console                                                                               |
+| metal_console_resources                   |           | Sets the given container resources                                                                                                 |
+| metal_console_bmc_proxy_endpoints         |           | Endpoints to reverse bmc-proxies inside the partitions for establishing machine console connections, requires external dns entries | 
+| metal_console_bmc_proxy_certs_ca_cert     | yes       | The bmc-proxy ca certificate as a string                                                                                           |
+| metal_console_bmc_proxy_certs_server_key  | yes       | The bmc-proxy server key as a string                                                                                               |
+| metal_console_bmc_proxy_certs_server_pub  | yes       | The bmc-proxy server public key as a string                                                                                        |
+| metal_console_bmc_proxy_certs_client_cert | yes       | The bmc-proxy client certificate as a string                                                                                       |
+| metal_console_bmc_proxy_certs_client_key  | yes       | The bmc-proxy client key as a string                                                                                               |
 
 # Ingress
 

--- a/control-plane/roles/metal/defaults/main/main.yaml
+++ b/control-plane/roles/metal/defaults/main/main.yaml
@@ -16,7 +16,6 @@ metal_api_metrics_port: 2112
 metal_masterdata_api_port: 8443
 metal_masterdata_api_metrics_port: 2113
 metal_console_port: 10001
-metal_bmc_reverse_proxy_port: 3333
 
 # metal-api
 metal_api_replicas: 3
@@ -62,14 +61,13 @@ metal_masterdata_api_projects: []
 metal_console_replicas: 3
 metal_console_resources:
 
-metal_mgmt_services: []
-# expected metal_mgmt_services data structure looks like this:
-# metal_mgmt_services:
-# - id: partition-a-mgmt-service
-#   port: port-of-the-reverse-proxies
-#   ips:
-#     - ip-of-your-mgmt-server-01
-#     - ip-of-your-mgmt-server-02
+metal_console_bmc_proxy_endpoints: []
+# expected metal_console_bmc_proxy_endpoints data structure looks like this:
+# metal_console_bmc_proxy_endpoints:
+# - name: partition-a
+#   endpoint: bmc-proxy-a-address.example.com
+# - name: partition-b
+#   endpoint: bmc-proxy-b-address.example.com
 
 # ingress
 metal_deploy_ingress: true

--- a/control-plane/roles/metal/files/metal-control-plane/templates/metal-console.yaml
+++ b/control-plane/roles/metal/files/metal-control-plane/templates/metal-console.yaml
@@ -76,3 +76,14 @@ spec:
     targetPort: 10001
   selector:
     app: metal-console
+
+{{- range .Values.bmc_proxy_endpoints }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .name }}-bmc-proxy
+spec:
+  type: ExternalName
+  externalName: {{ .endpoint }}
+{{- end }}

--- a/control-plane/roles/metal/files/metal-control-plane/values.yaml
+++ b/control-plane/roles/metal/files/metal-control-plane/values.yaml
@@ -48,7 +48,6 @@ ports:
   masterdata_api: 8443
   masterdata_api_metrics: 2113
   metal_console: 10001
-  bmc_reverse_proxy: 3333
 
 metal_api:
   replicas: 3
@@ -113,7 +112,7 @@ masterdata_api:
 metal_console:
   replicas: 3
 
-mgmtservices: []
+bmc_proxy_endpoints: []
 
 ingress_public_dns:
 deploy_ingress: true

--- a/control-plane/roles/metal/templates/metal-values.j2
+++ b/control-plane/roles/metal/templates/metal-values.j2
@@ -39,7 +39,6 @@ ports:
   masterdata_api: {{ metal_masterdata_api_port }}
   masterdata_api_metrics: {{ metal_masterdata_api_metrics_port }}
   metal_console: {{ metal_console_port }}
-  bmc_reverse_proxy: {{ metal_bmc_reverse_proxy_port }}
 
 metal_api:
   db_address: "{{ metal_api_db_address }}"
@@ -129,7 +128,7 @@ masterdata_api:
     tenant_id: {{ metal_masterdata_api_provider_tenant }}
 {% endfor %}
 
-mgmtservices: {{ metal_mgmt_services | to_json }}
+bmc_proxy_endpoints: {{ metal_console_bmc_proxy_endpoints | to_json }}
 
 ingress_public_dns: "{{ metal_ingress_dns }}"
 deploy_ingress: {{ metal_deploy_ingress }}


### PR DESCRIPTION
Load balancing must be provided at the destination, not in our control plane cluster.