### PR TITLE
Disable metal-console by default.

### DIFF
--- a/control-plane/roles/metal/README.md
+++ b/control-plane/roles/metal/README.md
@@ -102,15 +102,16 @@ You can look up all the default values of this role [here](defaults/main/main.ya
 
 # metal-console
 
-| Name                                      | Mandatory | Description                                                                                                                        |
-| ----------------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| metal_console_replicas                    |           | The number of deployed replicas of the metal-console                                                                               |
-| metal_console_resources                   |           | Sets the given container resources                                                                                                 |
-| metal_console_bmc_proxy_certs_ca_cert     | yes       | The bmc-proxy ca certificate as a string                                                                                           |
-| metal_console_bmc_proxy_certs_server_key  | yes       | The bmc-proxy server key as a string                                                                                               |
-| metal_console_bmc_proxy_certs_server_pub  | yes       | The bmc-proxy server public key as a string                                                                                        |
-| metal_console_bmc_proxy_certs_client_cert | yes       | The bmc-proxy client certificate as a string                                                                                       |
-| metal_console_bmc_proxy_certs_client_key  | yes       | The bmc-proxy client key as a string                                                                                               |
+| Name                                      | Mandatory | Description                                                        |
+| ----------------------------------------- | --------- | ------------------------------------------------------------------ |
+| metal_console_enabled                     |           | Whether to deploy or not to deploy the metal-console               |
+| metal_console_replicas                    |           | The number of deployed replicas of the metal-console               |
+| metal_console_resources                   |           | Sets the given container resources                                 |
+| metal_console_bmc_proxy_certs_ca_cert     |           | The bmc-proxy ca certificate as a string (required if enabled)     |
+| metal_console_bmc_proxy_certs_server_key  |           | The bmc-proxy server key as a string (required if enabled)         |
+| metal_console_bmc_proxy_certs_server_pub  |           | The bmc-proxy server public key as a string (required if enabled)  |
+| metal_console_bmc_proxy_certs_client_cert |           | The bmc-proxy client certificate as a string (required if enabled) |
+| metal_console_bmc_proxy_certs_client_key  |           | The bmc-proxy client key as a string (required if enabled)         |
 
 # Ingress
 

--- a/control-plane/roles/metal/defaults/main/main.yaml
+++ b/control-plane/roles/metal/defaults/main/main.yaml
@@ -58,8 +58,14 @@ metal_masterdata_api_tenants: []
 metal_masterdata_api_projects: []
 
 # metal-console
+metal_console_enabled: false
 metal_console_replicas: 3
 metal_console_resources:
+metal_console_bmc_proxy_certs_server_key:
+metal_console_bmc_proxy_certs_server_pub:
+metal_console_bmc_proxy_certs_client_key:
+metal_console_bmc_proxy_certs_client_cert:
+metal_console_bmc_proxy_certs_ca_cert:
 
 # ingress
 metal_deploy_ingress: true

--- a/control-plane/roles/metal/files/metal-control-plane/templates/metal-console.yaml
+++ b/control-plane/roles/metal/files/metal-control-plane/templates/metal-console.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.metal_console.enabled }}
 ---
 apiVersion: v1
 kind: Secret
@@ -76,3 +77,4 @@ spec:
     targetPort: 10001
   selector:
     app: metal-console
+{{- end }}

--- a/control-plane/roles/metal/files/metal-control-plane/values.yaml
+++ b/control-plane/roles/metal/files/metal-control-plane/values.yaml
@@ -110,6 +110,7 @@ masterdata_api:
   hmac: ""
 
 metal_console:
+  enabled: false
   replicas: 3
 
 ingress_public_dns:

--- a/control-plane/roles/metal/tasks/main.yaml
+++ b/control-plane/roles/metal/tasks/main.yaml
@@ -20,11 +20,6 @@
       - metal_masterdata_api_tls_client_key is defined
       - metal_console_image_name is defined
       - metal_console_image_tag is defined
-      - metal_console_bmc_proxy_certs_server_key is defined
-      - metal_console_bmc_proxy_certs_server_pub is defined
-      - metal_console_bmc_proxy_certs_client_key is defined
-      - metal_console_bmc_proxy_certs_client_cert is defined
-      - metal_console_bmc_proxy_certs_ca_cert is defined
 
 - name: Deploy metal control plane
   include_role:

--- a/control-plane/roles/metal/templates/metal-values.j2
+++ b/control-plane/roles/metal/templates/metal-values.j2
@@ -30,6 +30,7 @@ resources:
 {% endif %}
 
 metal_console:
+  enabled: {{ metal_console_enabled }}
   replicas: "{{ metal_console_replicas }}"
 
 ports:


### PR DESCRIPTION
It requires special configuration to work. Users should explicitly decide to enable it as otherwise they need to provide bmc proxy certificates and it probably won't work on first attempt. Also completely irrelevant for mini-lab (where certs would also be required).