### PR TITLE
use eth0 as brigde mac

### DIFF
--- a/partition/roles/leaf/files/bridgemac.json
+++ b/partition/roles/leaf/files/bridgemac.json
@@ -1,0 +1,7 @@
+{
+  "bridge": {
+    "module_globals": {
+      "bridge_mac_iface": ["eth0", "eth1"]
+    }
+  }
+}

--- a/partition/roles/leaf/tasks/main.yaml
+++ b/partition/roles/leaf/tasks/main.yaml
@@ -25,3 +25,9 @@
   when:
     - '"10.0.1.0/24" not in route_check.stdout'
     - dhcp_server_ip is defined
+
+- name: create bridgemac.json
+  copy:
+    src: bridgemac.json
+    dest: /etc/network/ifupdown2/policy.d/bridgemac.json
+  notify: restart ifreload

--- a/partition/roles/leaf/tasks/main.yaml
+++ b/partition/roles/leaf/tasks/main.yaml
@@ -30,4 +30,4 @@
   copy:
     src: bridgemac.json
     dest: /etc/network/ifupdown2/policy.d/bridgemac.json
-  notify: restart ifreload
+  notify: reload interfaces


### PR DESCRIPTION
prevents changing the mac of the bridge interface on every ifreload, which leads to route flapping