### PR TITLE
helm_force is now set to false by default, remove obsolete definitions.

### DIFF
--- a/control-plane/roles/metal/tasks/main.yaml
+++ b/control-plane/roles/metal/tasks/main.yaml
@@ -33,7 +33,6 @@
     # deployment can take a while due to post install hooks, therefore increasing the timeout for this chart...
     helm_timeout: 600s
     helm_chart_inject_config_hash: yes
-    helm_force: false
 
 - name: Set services for patching ingress controller service exposal
   set_fact:


### PR DESCRIPTION
References https://github.com/metal-stack/ansible-common/pull/9.