### PR TITLE
Remove default image for bmc-catcher.

### DIFF
--- a/partition/roles/bmc-catcher/README.md
+++ b/partition/roles/bmc-catcher/README.md
@@ -9,6 +9,6 @@ This role uses variables from [partition-defaults](/partition). So, make sure yo
 You can look up all the default values of this role [here](defaults/main.yaml).
 
 | Name                   | Mandatory | Description                      |
-| -----------------------| --------- | -------------------------------- |
-| bmc_catcher_image_name |           | Image version of the bmc-catcher |
+| ---------------------- | --------- | -------------------------------- |
+| bmc_catcher_image_name | yes       | Image version of the bmc-catcher |
 | bmc_catcher_image_tag  | yes       | Image tag of the bmc-catcher     |

--- a/partition/roles/bmc-catcher/defaults/main/main.yaml
+++ b/partition/roles/bmc-catcher/defaults/main/main.yaml
@@ -1,3 +1,2 @@
 ---
-bmc_catcher_image_name: metalstack/bmc-catcher
 bmc_catcher_ignore_macs: []

--- a/partition/roles/bmc-catcher/tasks/main.yaml
+++ b/partition/roles/bmc-catcher/tasks/main.yaml
@@ -8,6 +8,7 @@
     quiet: yes
     that:
       - bmc_catcher_image_tag is defined
+      - bmc_catcher_image_name is defined
 
 - name: deploy bmc-catcher service
   include_role:


### PR DESCRIPTION
This default will override the version pulled from the release vector.