### PR TITLE
Allow setting pull secrets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,13 @@ setup_yaml:
     # the metal_stack_release variable is provided through role defaults of this project
     # use release versions if you want to have stable deployment!
 ```
+
+## Variables
+
+There are global defaults for all roles of this project defined [here](defaults/main.yaml).
+
+| Name                         | Mandatory | Description                               |
+| ---------------------------- | --------- | ----------------------------------------- |
+| metal_registry_auth_enabled  |           | Enables deployment of image pull secrets  |
+| metal_registry_auth_user     |           | The default auth user for the registry    |
+| metal_registry_auth_password |           | The password for the user of the registry |

--- a/control-plane/roles/ipam-db/defaults/main/main.yaml
+++ b/control-plane/roles/ipam-db/defaults/main/main.yaml
@@ -29,3 +29,11 @@ ipam_db_resources:
   limits:
     memory: "256Mi"
     cpu: "100m"
+
+ipam_db_registry_auth_enabled: "{{ metal_registry_auth_enabled }}"
+ipam_db_registry_auth:
+  auths:
+    docker.io:
+      username: "{{ metal_registry_auth_user }}"
+      password: "{{ metal_registry_auth_password }}"
+      auth: "{{ (metal_registry_auth_user + ':' + metal_registry_auth_password) | b64encode }}"

--- a/control-plane/roles/ipam-db/tasks/main.yaml
+++ b/control-plane/roles/ipam-db/tasks/main.yaml
@@ -21,6 +21,8 @@
     postgres_image_pull_policy: "{{ ipam_db_image_pull_policy }}"
     postgres_image_name: "{{ ipam_db_image_name }}"
     postgres_image_tag: "{{ ipam_db_image_tag }}"
+    postgres_registry_auth_enabled: "{{ ipam_db_registry_auth_enabled }}"
+    postgres_registry_auth: "{{ ipam_db_registry_auth }}"
     postgres_storage_size: "{{ ipam_db_storage_size }}"
     postgres_storage_class: "{{ ipam_db_storage_class }}"
     postgres_db: "{{ ipam_db_db }}"

--- a/control-plane/roles/masterdata-db/defaults/main/main.yaml
+++ b/control-plane/roles/masterdata-db/defaults/main/main.yaml
@@ -29,3 +29,11 @@ masterdata_db_resources:
   limits:
     memory: "256Mi"
     cpu: "100m"
+
+masterdata_db_registry_auth_enabled: "{{ metal_registry_auth_enabled }}"
+masterdata_db_registry_auth:
+  auths:
+    docker.io:
+      username: "{{ metal_registry_auth_user }}"
+      password: "{{ metal_registry_auth_password }}"
+      auth: "{{ (metal_registry_auth_user + ':' + metal_registry_auth_password) | b64encode }}"

--- a/control-plane/roles/masterdata-db/tasks/main.yaml
+++ b/control-plane/roles/masterdata-db/tasks/main.yaml
@@ -21,6 +21,8 @@
     postgres_image_pull_policy: "{{ masterdata_db_image_pull_policy }}"
     postgres_image_name: "{{ masterdata_db_image_name }}"
     postgres_image_tag: "{{ masterdata_db_image_tag }}"
+    postgres_registry_auth_enabled: "{{ masterdata_db_registry_auth_enabled }}"
+    postgres_registry_auth: "{{ masterdata_db_registry_auth }}"
     postgres_storage_size: "{{ masterdata_db_storage_size }}"
     postgres_storage_class: "{{ masterdata_db_storage_class }}"
     postgres_db: "{{ masterdata_db_db }}"

--- a/control-plane/roles/metal-db/defaults/main/main.yaml
+++ b/control-plane/roles/metal-db/defaults/main/main.yaml
@@ -28,3 +28,11 @@ metal_db_resources:
   limits:
     memory: "4Gi"
     cpu: "500m"
+
+metal_db_registry_auth_enabled: "{{ metal_registry_auth_enabled }}"
+metal_db_registry_auth:
+  auths:
+    docker.io:
+      username: "{{ metal_registry_auth_user }}"
+      password: "{{ metal_registry_auth_password }}"
+      auth: "{{ (metal_registry_auth_user + ':' + metal_registry_auth_password) | b64encode }}"

--- a/control-plane/roles/metal-db/tasks/main.yaml
+++ b/control-plane/roles/metal-db/tasks/main.yaml
@@ -20,6 +20,8 @@
     rethinkdb_namespace: "{{ metal_db_namespace }}"
     rethinkdb_image_pull_policy: "{{ metal_db_image_pull_policy }}"
     rethinkdb_image_name: "{{ metal_db_image_name }}"
+    rethinkdb_registry_auth_enabled: "{{ metal_db_registry_auth_enabled }}"
+    rethinkdb_registry_auth: "{{ metal_db_registry_auth }}"
     rethinkdb_image_tag: "{{ metal_db_image_tag }}"
     rethinkdb_storage_size: "{{ metal_db_storage_size }}"
     rethinkdb_storage_class: "{{ metal_db_storage_class }}"

--- a/control-plane/roles/nsq/defaults/main/main.yaml
+++ b/control-plane/roles/nsq/defaults/main/main.yaml
@@ -27,3 +27,11 @@ nsq_tls_enabled: false
 nsq_certs_client_key:
 nsq_certs_client_cert:
 nsq_certs_ca_cert:
+
+nsq_registry_auth_enabled: "{{ metal_registry_auth_enabled }}"
+nsq_registry_auth:
+  auths:
+    docker.io:
+      username: "{{ metal_registry_auth_user }}"
+      password: "{{ metal_registry_auth_password }}"
+      auth: "{{ (metal_registry_auth_user + ':' + metal_registry_auth_password) | b64encode }}"

--- a/control-plane/roles/nsq/templates/nsq.yaml
+++ b/control-plane/roles/nsq/templates/nsq.yaml
@@ -6,6 +6,18 @@ metadata:
   labels:
     app: "metal-stack-control-plane"
     name: "{{ metal_control_plane_namespace }}"
+{% if nsq_registry_auth_enabled %}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: nsq-registry-credentials
+  name: nsq-registry-credentials
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ nsq_registry_auth | to_json | b64encode }}
+{% endif %}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -24,6 +36,10 @@ spec:
       labels:
         app: nsqd
     spec:
+{% if nsq_registry_auth_enabled %}
+      imagePullSecrets:
+      - name: nsq-registry-credentials
+{% endif %}
       containers:
       - name: nsqd
         args:

--- a/control-plane/roles/postgres-backup-restore/README.md
+++ b/control-plane/roles/postgres-backup-restore/README.md
@@ -12,6 +12,8 @@ You can look up all the default values of this role [here](defaults/main/main.ya
 | ------------------------------------------------------- | --------- | ------------------------------------------------------------------------ |
 | postgres_image_name                                     | yes       | Image version of the postgres                                            |
 | postgres_image_tag                                      | yes       | Image tag of the postgres                                                |
+| postgres_registry_auth_enabled                          |           | Enables registry authentication                                          |
+| postgres_registry_auth                                  |           | The dockerconfigjson content used for registry authentication            |
 | postgres_image_pull_policy                              |           | Image pull policy (defaults to IfNotPresent)                             |
 | postgres_name                                           |           | The name of the postgres instance                                        |
 | postgres_namespace                                      |           | The deployment's target namespace                                        |

--- a/control-plane/roles/postgres-backup-restore/defaults/main/main.yaml
+++ b/control-plane/roles/postgres-backup-restore/defaults/main/main.yaml
@@ -35,3 +35,11 @@ postgres_resources:
   limits:
     memory: "256Mi"
     cpu: "100m"
+
+postgres_registry_auth_enabled: "{{ metal_registry_auth_enabled }}"
+postgres_registry_auth:
+  auths:
+    docker.io:
+      username: "{{ metal_registry_auth_user }}"
+      password: "{{ metal_registry_auth_password }}"
+      auth: "{{ (metal_registry_auth_user + ':' + metal_registry_auth_password) | b64encode }}"

--- a/control-plane/roles/postgres-backup-restore/templates/postgres.yaml
+++ b/control-plane/roles/postgres-backup-restore/templates/postgres.yaml
@@ -6,6 +6,18 @@ metadata:
   labels:
     app: "metal-stack-control-plane"
     name: "{{ metal_control_plane_namespace }}"
+{% if postgres_registry_auth_enabled %}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ postgres_name }}-registry-credentials
+  name: {{ postgres_name }}-registry-credentials
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ postgres_registry_auth | to_json | b64encode }}
+{% endif %}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -24,6 +36,10 @@ spec:
       labels:
         app: {{ postgres_name }}
     spec:
+{% if postgres_registry_auth_enabled %}
+      imagePullSecrets:
+      - name: {{ postgres_name }}-registry-credentials
+{% endif %}
       containers:
       - name: postgres
         image: {{ postgres_image_name }}:{{ postgres_image_tag }}

--- a/control-plane/roles/rethinkdb-backup-restore/README.md
+++ b/control-plane/roles/rethinkdb-backup-restore/README.md
@@ -12,6 +12,8 @@ You can look up all the default values of this role [here](defaults/main/main.ya
 | -------------------------------------------------------- | --------- | ------------------------------------------------------------------------- |
 | rethinkdb_image_name                                     | yes       | Image version of the rethinkdb                                            |
 | rethinkdb_image_tag                                      | yes       | Image tag of the rethinkdb                                                |
+| rethinkdb_registry_auth_enabled                          |           | Enables registry authentication                                           |
+| rethinkdb_registry_auth                                  |           | The dockerconfigjson content used for registry authentication             |
 | rethinkdb_image_pull_policy                              | yes       | Image pull policy (defaults to IfNotPresent)                              |
 | rethinkdb_name                                           |           | The name of the rethinkdb instance                                        |
 | rethinkdb_namespace                                      |           | The deployment's target namespace                                         |

--- a/control-plane/roles/rethinkdb-backup-restore/defaults/main/main.yaml
+++ b/control-plane/roles/rethinkdb-backup-restore/defaults/main/main.yaml
@@ -28,3 +28,11 @@ rethinkdb_resources:
   limits:
     memory: "4Gi"
     cpu: "500m"
+
+rethinkdb_registry_auth_enabled: "{{ metal_registry_auth_enabled }}"
+rethinkdb_registry_auth:
+  auths:
+    docker.io:
+      username: "{{ metal_registry_auth_user }}"
+      password: "{{ metal_registry_auth_password }}"
+      auth: "{{ (metal_registry_auth_user + ':' + metal_registry_auth_password) | b64encode }}"

--- a/control-plane/roles/rethinkdb-backup-restore/templates/rethinkdb.yaml
+++ b/control-plane/roles/rethinkdb-backup-restore/templates/rethinkdb.yaml
@@ -1,3 +1,15 @@
+{% if rethinkdb_registry_auth_enabled %}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ rethinkdb_name }}-registry-credentials
+  name: {{ rethinkdb_name }}-registry-credentials
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ rethinkdb_registry_auth | to_json | b64encode }}
+{% endif %}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -16,6 +28,10 @@ spec:
       labels:
         app: {{ rethinkdb_name }}
     spec:
+  {% if rethinkdb_registry_auth_enabled %}
+        imagePullSecrets:
+        - name: {{ rethinkdb_name }}-registry-credentials
+  {% endif %}
       containers:
       - name: rethinkdb
         image: {{ rethinkdb_image_name }}:{{ rethinkdb_image_tag }}

--- a/control-plane/roles/rethinkdb-backup-restore/templates/rethinkdb.yaml
+++ b/control-plane/roles/rethinkdb-backup-restore/templates/rethinkdb.yaml
@@ -28,10 +28,10 @@ spec:
       labels:
         app: {{ rethinkdb_name }}
     spec:
-  {% if rethinkdb_registry_auth_enabled %}
-        imagePullSecrets:
-        - name: {{ rethinkdb_name }}-registry-credentials
-  {% endif %}
+{% if rethinkdb_registry_auth_enabled %}
+      imagePullSecrets:
+      - name: {{ rethinkdb_name }}-registry-credentials
+{% endif %}
       containers:
       - name: rethinkdb
         image: {{ rethinkdb_image_name }}:{{ rethinkdb_image_tag }}

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,4 +1,8 @@
 ---
+metal_registry_auth_enabled: no
+metal_registry_auth_user: ""
+metal_registry_auth_password: ""
+
 metal_stack_release:
   mapping:
     # binaries


### PR DESCRIPTION
This is particularly interesting for our integration tests where we regularly run into Docker Hub rate limits. So, this PR enables deploying pull secrets for images from Docker Hub:

- NSQ
- Postgres
- Rethinkdb