### PR TITLE
Enable image-cache to cache partition kernels and boot images, too.

### DIFF
--- a/partition/roles/image-cache/README.md
+++ b/partition/roles/image-cache/README.md
@@ -6,6 +6,8 @@ The image-cache is highly-available and falls back to the "global image store" (
 
 For pointing your images to the image cache, you are gonna use HTTP image URLs in the metal-api. CoreDNS will intercept HTTP image requests on port 80 and redirect them to the partition's image cache. The global image store will be accessed through HTTPS in case of a cache miss.
 
+The cache is also capable of providing kernels and boot images configured in the metal-api.
+
 ## Requirements
 
 - Your DHCP inside your partition's PXE boot network needs to point the machines to the image cache servers for their DNS resolution
@@ -29,7 +31,7 @@ Introducing a partition-local cache for machine images brings the following adva
 - Haproxy is used to dispatch HTTP image downloads to the fastest available backends
   - If the image cache is running properly in the partition -> client downloads the image from there
     - Haproxy prefers the image cache on the same server and load-balances between the other configured instances in case the local instance is down
-    - If the image cache returns 404 not found on the requested image (cache miss), it redirects the requester to the global image store (HTTPS)
+    - If the image cache does not find the requested resource, the cache returns a 307 redirect (cache miss), the requester will now attempt to access the same resource via HTTPS
     - The HTTPS frontend forwards the request to the global image store (client does SSL)
   - If the image cache is not running on any of the servers -> retrieve image from global image store
     - Haproxy will handle the SSL
@@ -76,7 +78,7 @@ Introducing a partition-local cache for machine images brings the following adva
 | image_cache_haproxy_kernel_fallback_backend_server                     |           | The domain name of the "global kernel store" (internet, must have valid HTTPS)                                            |
 | image_cache_haproxy_kernel_fallback_backend_server_health_endpoint     |           | The health endpoint which is expected to return 200 of the "global kernel store"                                          |
 | image_cache_haproxy_boot_image_fallback_backend_server                 |           | The domain name of the "global boot image store" (internet, must have valid HTTPS)                                        |
-| image_cache_haproxy_boot_image_fallback_backend_server_health_endpoint |           | The health endpoint which is expected to return 200 of the "global boot image store"                                      | 
+| image_cache_haproxy_boot_image_fallback_backend_server_health_endpoint |           | The health endpoint which is expected to return 200 of the "global boot image store"                                      |
 
 ### Host Vars
 

--- a/partition/roles/image-cache/README.md
+++ b/partition/roles/image-cache/README.md
@@ -51,24 +51,32 @@ Introducing a partition-local cache for machine images brings the following adva
 
 #### Configuration
 
-| Name                                                        | Mandatory | Description                                                                                                               |
-| ----------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------- |
-| image_cache_global_image_stores                             |           | The image store addresses for which the DNS requests are intercepted and pointed to the image cache                       |
-| image_cache_external_dns_servers                            |           | DNS servers that are used for resolving all other DNS requests                                                            |
-| image_cache_sync_max_cache_size                             |           | Maximum size that the cache should have in the end (can exceed if min amount of images for all image variants is reached) |
-| image_cache_sync_expiration_grace_period                    |           | The amount of days to still sync images even if they have already expired in the metal-api                                | 
-| image_cache_sync_max_images_per_name                        |           | Maximum amount of images to cache for an image variant                                                                    |
-| image_cache_sync_min_images_per_name                        |           | Minimum amount of images to keep of an image variant                                                                      |
-| image_cache_sync_metal_api_endpoint                         | yes       | Endpoint of the metal-api                                                                                                 |
-| image_cache_sync_metal_api_view_hmac                        | yes       | HMAC of the metal-api (requires view access)                                                                              |
-| image_cache_sync_schedule                                   |           | Cron sync schedule                                                                                                        |
-| image_cache_sync_excludes                                   |           | URL paths to exclude from the sync                                                                                        |
-| image_cache_sync_host_path                                  |           | Root path of where to store the images                                                                                    |
-| image_cache_sync_port                                       |           | The image tag of metal-cache-image-sync                                                                                   |
-| image_cache_coredns_host_dir_path                           |           | The host path for CoreDNS configuration                                                                                   |
-| image_cache_haproxy_host_dir_path                           |           | The host path for haproxy configuration                                                                                   |
-| image_cache_haproxy_fallback_backend_server                 |           | The domain name of the "global image store" (internet, must have valid HTTPS)                                             |
-| image_cache_haproxy_fallback_backend_server_health_endpoint |           | The health endpoint which is expected to return 200 of the "global image store"                                           |
+| Name                                                                   | Mandatory | Description                                                                                                               |
+| ---------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------- |
+| image_cache_intercept_domains                                          |           | The domains for which the DNS requests are intercepted and pointed to the image cache                                     |
+| image_cache_kernel_cache_enabled                                       |           | Enables caching partition boot kernels                                                                                    |
+| image_cache_boot_image_cache_enabled                                   |           | Enables caching partition boot images                                                                                     |
+| image_cache_external_dns_servers                                       |           | DNS servers that are used for resolving all other DNS requests                                                            |
+| image_cache_sync_max_cache_size                                        |           | Maximum size that the cache should have in the end (can exceed if min amount of images for all image variants is reached) |
+| image_cache_sync_expiration_grace_period                               |           | The amount of days to still sync images even if they have already expired in the metal-api                                |
+| image_cache_sync_max_images_per_name                                   |           | Maximum amount of images to cache for an image variant                                                                    |
+| image_cache_sync_min_images_per_name                                   |           | Minimum amount of images to keep of an image variant                                                                      |
+| image_cache_sync_metal_api_endpoint                                    | yes       | Endpoint of the metal-api                                                                                                 |
+| image_cache_sync_metal_api_view_hmac                                   | yes       | HMAC of the metal-api (requires view access)                                                                              |
+| image_cache_sync_schedule                                              |           | Cron sync schedule                                                                                                        |
+| image_cache_sync_excludes                                              |           | URL paths to exclude from the sync                                                                                        |
+| image_cache_sync_host_path                                             |           | Root path of where to store the images                                                                                    |
+| image_cache_sync_port                                                  |           | The image tag of metal-cache-image-sync                                                                                   |
+| image_cache_coredns_host_dir_path                                      |           | The host path for CoreDNS configuration                                                                                   |
+| image_cache_kernel_route_prefix                                        |           | The route prefix to distinguish whether the kernel cache backend is used or not                                           |
+| image_cache_boot_image_route_prefix                                    |           | The route prefix to distinguish whether the boot image cache backend is used or not                                       |
+| image_cache_haproxy_host_dir_path                                      |           | The host path for haproxy configuration                                                                                   |
+| image_cache_haproxy_fallback_backend_server                            |           | The domain name of the "global image store" (internet, must have valid HTTPS)                                             |
+| image_cache_haproxy_fallback_backend_server_health_endpoint            |           | The health endpoint which is expected to return 200 of the "global image store"                                           |
+| image_cache_haproxy_kernel_fallback_backend_server                     |           | The domain name of the "global kernel store" (internet, must have valid HTTPS)                                            |
+| image_cache_haproxy_kernel_fallback_backend_server_health_endpoint     |           | The health endpoint which is expected to return 200 of the "global kernel store"                                          |
+| image_cache_haproxy_boot_image_fallback_backend_server                 |           | The domain name of the "global boot image store" (internet, must have valid HTTPS)                                        |
+| image_cache_haproxy_boot_image_fallback_backend_server_health_endpoint |           | The health endpoint which is expected to return 200 of the "global boot image store"                                      | 
 
 ### Host Vars
 

--- a/partition/roles/image-cache/defaults/main/main.yaml
+++ b/partition/roles/image-cache/defaults/main/main.yaml
@@ -1,6 +1,12 @@
 ---
-image_cache_global_image_stores:
+image_cache_intercept_domains:
   - images.metal-stack.io
+  - github.com
+
+image_cache_kernel_cache_enabled: true
+image_cache_kernel_route_prefix: "/metal-stack/kernel"
+image_cache_boot_image_cache_enabled: true
+image_cache_boot_image_route_prefix: "/metal-stack/metal-hammer"
 
 image_cache_external_dns_servers:
   - name: google
@@ -26,6 +32,8 @@ image_cache_sync_metal_api_view_hmac:
 image_cache_sync_schedule: "*/10 * * * *"
 image_cache_sync_host_path: /metal-image-cache-sync
 image_cache_sync_port: 9001
+image_cache_sync_kernel_port: 9002
+image_cache_sync_boot_image_port: 9003
 image_cache_sync_excludes:
   - "/pull_requests/"
 
@@ -34,3 +42,7 @@ image_cache_sync_excludes:
 # spread images across too many locations
 image_cache_haproxy_fallback_backend_server: images.metal-stack.io
 image_cache_haproxy_fallback_backend_server_health_endpoint: /
+image_cache_haproxy_kernel_fallback_backend_server: github.com
+image_cache_haproxy_kernel_fallback_backend_server_health_endpoint: /
+image_cache_haproxy_boot_image_fallback_backend_server: github.com
+image_cache_haproxy_boot_image_fallback_backend_server_health_endpoint: /

--- a/partition/roles/image-cache/tasks/image-sync.yaml
+++ b/partition/roles/image-cache/tasks/image-sync.yaml
@@ -18,5 +18,5 @@
       METAL_IMAGE_CACHE_SYNC_EXCLUDES: "{{ image_cache_sync_excludes | join(',') }}"
       METAL_IMAGE_CACHE_SYNC_EXPIRATION_GRACE_PERIOD: "{{ image_cache_sync_expiration_grace_period }}"
     systemd_docker_volumes:
-      - "{{ image_cache_sync_host_path }}:/var/lib/metal-image-cache-sync/images"
+      - "{{ image_cache_sync_host_path }}:/var/lib/metal-image-cache-sync"
     systemd_docker_ports: "{{ lookup('template', 'metal-image-cache-ports.j2') | from_yaml }}"

--- a/partition/roles/image-cache/tasks/image-sync.yaml
+++ b/partition/roles/image-cache/tasks/image-sync.yaml
@@ -7,7 +7,8 @@
     systemd_docker_image_name: "{{ image_cache_sync_image_name }}"
     systemd_docker_image_tag: "{{ image_cache_sync_image_tag }}"
     systemd_service_environment:
-      METAL_IMAGE_CACHE_SYNC_BIND_ADDRESS: "0.0.0.0:3000"
+      METAL_IMAGE_CACHE_SYNC_ENABLE_KERNEL_CACHE: "{{ image_cache_kernel_cache_enabled }}"
+      METAL_IMAGE_CACHE_SYNC_ENABLE_BOOT_IMAGE_CACHE: "{{ image_cache_boot_image_cache_enabled }}"
       METAL_IMAGE_CACHE_SYNC_MAX_CACHE_SIZE: "{{ image_cache_sync_max_cache_size }}"
       METAL_IMAGE_CACHE_SYNC_MAX_IMAGES_PER_NAME: "{{ image_cache_sync_max_images_per_name }}"
       METAL_IMAGE_CACHE_SYNC_MIN_IMAGES_PER_NAME: "{{ image_cache_sync_min_images_per_name }}"
@@ -18,6 +19,4 @@
       METAL_IMAGE_CACHE_SYNC_EXPIRATION_GRACE_PERIOD: "{{ image_cache_sync_expiration_grace_period }}"
     systemd_docker_volumes:
       - "{{ image_cache_sync_host_path }}:/var/lib/metal-image-cache-sync/images"
-    systemd_docker_ports:
-      - host_port: "{{ image_cache_sync_port }}"
-        target_port: "3000"
+    systemd_docker_ports: "{{ lookup('template', 'metal-image-cache-ports.j2') | from_yaml }}"

--- a/partition/roles/image-cache/templates/corefile.j2
+++ b/partition/roles/image-cache/templates/corefile.j2
@@ -4,7 +4,7 @@
     errors
 }
 
-{% for cache in image_cache_global_image_stores %}
+{% for cache in image_cache_intercept_domains %}
 {{ cache }}:53 {
     loadbalance round_robin
     file /root/metal-image-cache.db

--- a/partition/roles/image-cache/templates/haproxy.j2
+++ b/partition/roles/image-cache/templates/haproxy.j2
@@ -49,7 +49,7 @@ frontend images
   use_backend global_kernel_store if partition_local_kernel_cache_dead
 {% endif %}
 
-{% if image_cache_enable_boot_image_cache %}
+{% if image_cache_boot_image_cache_enabled %}
   acl has_boot_image_path_prefix path_beg {{ image_cache_boot_image_route_prefix }}
   use_backend partition_local_boot_image_cache if has_boot_image_path_prefix
   acl partition_local_boot_image_cache_dead nbsrv(partition_local_boot_image_cache) eq 0
@@ -65,7 +65,7 @@ frontend images
 {% if image_cache_kernel_cache_enabled %}
   http-response set-header Location https://{{ image_cache_haproxy_kernel_fallback_backend_server }}%[capture.req.uri] if not_found has_kernel_path_prefix
 {% endif %}
-{% if image_cache_enable_boot_image_cache %}
+{% if image_cache_boot_image_cache_enabled %}
   http-response set-header Location https://{{ image_cache_haproxy_boot_image_fallback_backend_server }}%[capture.req.uri] if not_found has_boot_image_path_prefix
 {% endif %}
   http-response set-header Location https://{{ image_cache_haproxy_fallback_backend_server }}%[capture.req.uri] if not_found
@@ -78,7 +78,7 @@ frontend images_passthrough
   acl has_kernel_path_prefix path_beg {{ image_cache_kernel_route_prefix }}
   use_backend global_kernel_store_passthrough if has_kernel_path_prefix
 {% endif %}
-{% if image_cache_enable_boot_image_cache %}
+{% if image_cache_boot_image_cache_enabled %}
   acl has_boot_image_path_prefix path_beg {{ image_cache_boot_image_route_prefix }}
   use_backend global_boot_image_store_passthrough if has_boot_image_path_prefix
 {% endif %}
@@ -95,7 +95,7 @@ backend global_kernel_store_passthrough
   server {{ image_cache_haproxy_kernel_fallback_backend_server }} {{ image_cache_haproxy_kernel_fallback_backend_server }}:443
 {% endif %}
 
-{% if image_cache_enable_boot_image_cache %}
+{% if image_cache_boot_image_cache_enabled %}
 backend global_boot_image_store_passthrough
   mode tcp
   server {{ image_cache_haproxy_boot_image_fallback_backend_server }} {{ image_cache_haproxy_boot_image_fallback_backend_server }}:443
@@ -121,7 +121,7 @@ backend partition_local_kernel_cache
 {% endfor %}
 {% endif %}
 
-{% if image_cache_enable_boot_image_cache %}
+{% if image_cache_boot_image_cache_enabled %}
 backend partition_local_boot_image_cache
   option httpchk
   http-check send meth GET uri /health ver HTTP/1.1 hdr host www
@@ -150,7 +150,7 @@ backend global_kernel_store
   server {{ image_cache_haproxy_kernel_fallback_backend_server }} {{ image_cache_haproxy_kernel_fallback_backend_server }}:443 ssl verify required ca-file ca-certificates.crt check inter 30s rise 2 fall 3 resolvers pubdns resolve-prefer ipv4
 {% endif %}
 
-{% if image_cache_enable_boot_image_cache %}
+{% if image_cache_boot_image_cache_enabled %}
 backend global_boot_image_store
   option httpchk
   http-check send meth GET uri {{ image_cache_haproxy_boot_image_fallback_backend_server_health_endpoint }} ver HTTP/1.1 hdr host {{ image_cache_haproxy_boot_image_fallback_backend_server }}

--- a/partition/roles/image-cache/templates/haproxy.j2
+++ b/partition/roles/image-cache/templates/haproxy.j2
@@ -60,16 +60,6 @@ frontend images
   use_backend global_image_store if partition_local_image_cache_dead
   default_backend partition_local_image_cache
 
-  acl not_found status 404
-  http-response set-status 302 if not_found
-{% if image_cache_kernel_cache_enabled %}
-  http-response set-header Location https://{{ image_cache_haproxy_kernel_fallback_backend_server }}%[capture.req.uri] if not_found has_kernel_path_prefix
-{% endif %}
-{% if image_cache_boot_image_cache_enabled %}
-  http-response set-header Location https://{{ image_cache_haproxy_boot_image_fallback_backend_server }}%[capture.req.uri] if not_found has_boot_image_path_prefix
-{% endif %}
-  http-response set-header Location https://{{ image_cache_haproxy_fallback_backend_server }}%[capture.req.uri] if not_found
-
 frontend images_passthrough
   mode tcp
   bind :443

--- a/partition/roles/image-cache/templates/haproxy.j2
+++ b/partition/roles/image-cache/templates/haproxy.j2
@@ -41,22 +41,65 @@ frontend images
   bind :80
   option forwardfor except 127.0.0.1
   option forwardfor header X-Real-IP
+
+{% if image_cache_kernel_cache_enabled %}
+  acl has_kernel_path_prefix path_beg {{ image_cache_kernel_route_prefix }}
+  use_backend partition_local_kernel_cache if has_kernel_path_prefix
+  acl partition_local_kernel_cache_dead nbsrv(partition_local_kernel_cache) eq 0
+  use_backend global_kernel_store if partition_local_kernel_cache_dead
+{% endif %}
+
+{% if image_cache_enable_boot_image_cache %}
+  acl has_boot_image_path_prefix path_beg {{ image_cache_boot_image_route_prefix }}
+  use_backend partition_local_boot_image_cache if has_boot_image_path_prefix
+  acl partition_local_boot_image_cache_dead nbsrv(partition_local_boot_image_cache) eq 0
+  use_backend global_boot_image_store if partition_local_boot_image_cache_dead
+{% endif %}
+
   acl partition_local_image_cache_dead nbsrv(partition_local_image_cache) eq 0
   use_backend global_image_store if partition_local_image_cache_dead
   default_backend partition_local_image_cache
 
   acl not_found status 404
-  http-response set-header Location https://{{ image_cache_haproxy_fallback_backend_server }}%[capture.req.uri] if not_found
   http-response set-status 302 if not_found
+{% if image_cache_kernel_cache_enabled %}
+  http-response set-header Location https://{{ image_cache_haproxy_kernel_fallback_backend_server }}%[capture.req.uri] if not_found has_kernel_path_prefix
+{% endif %}
+{% if image_cache_enable_boot_image_cache %}
+  http-response set-header Location https://{{ image_cache_haproxy_boot_image_fallback_backend_server }}%[capture.req.uri] if not_found has_boot_image_path_prefix
+{% endif %}
+  http-response set-header Location https://{{ image_cache_haproxy_fallback_backend_server }}%[capture.req.uri] if not_found
 
 frontend images_passthrough
   mode tcp
   bind :443
+
+{% if image_cache_kernel_cache_enabled %}
+  acl has_kernel_path_prefix path_beg {{ image_cache_kernel_route_prefix }}
+  use_backend global_kernel_store_passthrough if has_kernel_path_prefix
+{% endif %}
+{% if image_cache_enable_boot_image_cache %}
+  acl has_boot_image_path_prefix path_beg {{ image_cache_boot_image_route_prefix }}
+  use_backend global_boot_image_store_passthrough if has_boot_image_path_prefix
+{% endif %}
+
   default_backend global_image_store_passthrough
 
 backend global_image_store_passthrough
   mode tcp
-  server blobstore {{ image_cache_haproxy_fallback_backend_server }}:443
+  server {{ image_cache_haproxy_fallback_backend_server }} {{ image_cache_haproxy_fallback_backend_server }}:443
+
+{% if image_cache_kernel_cache_enabled %}
+backend global_kernel_store_passthrough
+  mode tcp
+  server {{ image_cache_haproxy_kernel_fallback_backend_server }} {{ image_cache_haproxy_kernel_fallback_backend_server }}:443
+{% endif %}
+
+{% if image_cache_enable_boot_image_cache %}
+backend global_boot_image_store_passthrough
+  mode tcp
+  server {{ image_cache_haproxy_boot_image_fallback_backend_server }} {{ image_cache_haproxy_boot_image_fallback_backend_server }}:443
+{% endif %}
 
 backend partition_local_image_cache
   option httpchk
@@ -67,10 +110,52 @@ backend partition_local_image_cache
   server {{ hostvars[host]['inventory_hostname'] }} {{ hostvars[host]['image_cache_internal_ip'] if 'image_cache_internal_ip' in hostvars[host] else hostvars[host]['ansible_host'] }}:{{ image_cache_sync_port }} check {{ 'backup' if inventory_hostname != hostvars[host]['inventory_hostname'] else '' }}
 {% endfor %}
 
+{% if image_cache_kernel_cache_enabled %}
+backend partition_local_kernel_cache
+  option httpchk
+  http-check send meth GET uri /health ver HTTP/1.1 hdr host www
+  http-check expect status 200
+  balance roundrobin
+{% for host in play_hosts %}
+  server {{ hostvars[host]['inventory_hostname'] }} {{ hostvars[host]['image_cache_internal_ip'] if 'image_cache_internal_ip' in hostvars[host] else hostvars[host]['ansible_host'] }}:{{ image_cache_sync_kernel_port }} check {{ 'backup' if inventory_hostname != hostvars[host]['inventory_hostname'] else '' }}
+{% endfor %}
+{% endif %}
+
+{% if image_cache_enable_boot_image_cache %}
+backend partition_local_boot_image_cache
+  option httpchk
+  http-check send meth GET uri /health ver HTTP/1.1 hdr host www
+  http-check expect status 200
+  balance roundrobin
+{% for host in play_hosts %}
+  server {{ hostvars[host]['inventory_hostname'] }} {{ hostvars[host]['image_cache_internal_ip'] if 'image_cache_internal_ip' in hostvars[host] else hostvars[host]['ansible_host'] }}:{{ image_cache_sync_boot_image_port }} check {{ 'backup' if inventory_hostname != hostvars[host]['inventory_hostname'] else '' }}
+{% endfor %}
+{% endif %}
+
 backend global_image_store
   option httpchk
-  http-check send meth GET uri {{ image_cache_haproxy_fallback_backend_server_health_endpoint}} ver HTTP/1.1 hdr host {{ image_cache_haproxy_fallback_backend_server }}
+  http-check send meth GET uri {{ image_cache_haproxy_fallback_backend_server_health_endpoint }} ver HTTP/1.1 hdr host {{ image_cache_haproxy_fallback_backend_server }}
   http-check expect status 200
   balance leastconn
   http-request set-header Host {{ image_cache_haproxy_fallback_backend_server }}
-  server blobstore {{ image_cache_haproxy_fallback_backend_server }}:443 ssl verify required ca-file ca-certificates.crt check inter 30s rise 2 fall 3 resolvers pubdns resolve-prefer ipv4
+  server {{ image_cache_haproxy_fallback_backend_server }} {{ image_cache_haproxy_fallback_backend_server }}:443 ssl verify required ca-file ca-certificates.crt check inter 30s rise 2 fall 3 resolvers pubdns resolve-prefer ipv4
+
+{% if image_cache_kernel_cache_enabled %}
+backend global_kernel_store
+  option httpchk
+  http-check send meth GET uri {{ image_cache_haproxy_kernel_fallback_backend_server_health_endpoint }} ver HTTP/1.1 hdr host {{ image_cache_haproxy_kernel_fallback_backend_server }}
+  http-check expect status 200
+  balance leastconn
+  http-request set-header Host {{ image_cache_haproxy_kernel_fallback_backend_server }}
+  server {{ image_cache_haproxy_kernel_fallback_backend_server }} {{ image_cache_haproxy_kernel_fallback_backend_server }}:443 ssl verify required ca-file ca-certificates.crt check inter 30s rise 2 fall 3 resolvers pubdns resolve-prefer ipv4
+{% endif %}
+
+{% if image_cache_enable_boot_image_cache %}
+backend global_boot_image_store
+  option httpchk
+  http-check send meth GET uri {{ image_cache_haproxy_boot_image_fallback_backend_server_health_endpoint }} ver HTTP/1.1 hdr host {{ image_cache_haproxy_boot_image_fallback_backend_server }}
+  http-check expect status 200
+  balance leastconn
+  http-request set-header Host {{ image_cache_haproxy_boot_image_fallback_backend_server }}
+  server {{ image_cache_haproxy_boot_image_fallback_backend_server }} {{ image_cache_haproxy_boot_image_fallback_backend_server }}:443 ssl verify required ca-file ca-certificates.crt check inter 30s rise 2 fall 3 resolvers pubdns resolve-prefer ipv4
+{% endif %}

--- a/partition/roles/image-cache/templates/haproxy.j2
+++ b/partition/roles/image-cache/templates/haproxy.j2
@@ -46,14 +46,14 @@ frontend images
   acl has_kernel_path_prefix path_beg {{ image_cache_kernel_route_prefix }}
   use_backend partition_local_kernel_cache if has_kernel_path_prefix
   acl partition_local_kernel_cache_dead nbsrv(partition_local_kernel_cache) eq 0
-  use_backend global_kernel_store if partition_local_kernel_cache_dead
+  use_backend global_kernel_store if has_kernel_path_prefix partition_local_kernel_cache_dead
 {% endif %}
 
 {% if image_cache_boot_image_cache_enabled %}
   acl has_boot_image_path_prefix path_beg {{ image_cache_boot_image_route_prefix }}
   use_backend partition_local_boot_image_cache if has_boot_image_path_prefix
   acl partition_local_boot_image_cache_dead nbsrv(partition_local_boot_image_cache) eq 0
-  use_backend global_boot_image_store if partition_local_boot_image_cache_dead
+  use_backend global_boot_image_store if has_boot_image_path_prefix partition_local_boot_image_cache_dead
 {% endif %}
 
   acl partition_local_image_cache_dead nbsrv(partition_local_image_cache) eq 0

--- a/partition/roles/image-cache/templates/metal-image-cache-ports.j2
+++ b/partition/roles/image-cache/templates/metal-image-cache-ports.j2
@@ -1,0 +1,10 @@
+- host_port: "{{ image_cache_sync_port }}"
+  target_port: "3000"
+{% if image_cache_kernel_cache_enabled %}
+- host_port: "{{ image_cache_sync_kernel_port }}"
+  target_port: "3001"
+{% endif %}
+{% if image_cache_boot_image_cache_enabled %}
+- host_port: "{{ image_cache_sync_boot_image_port }}"
+  target_port: "3002"
+{% endif %}

--- a/partition/roles/image-cache/templates/metal-image-cache.j2
+++ b/partition/roles/image-cache/templates/metal-image-cache.j2
@@ -1,4 +1,4 @@
-{% for cache in image_cache_global_image_stores %}
+{% for cache in image_cache_intercept_domains %}
 {{ cache }}.        IN  SOA {{ cache }}. {{ cache }}. 2015082541 7200 3600 1209600 3600
 {% for host in play_hosts %}
 {{ cache }}.        IN  A   {{ hostvars[host]['image_cache_internal_ip'] if 'image_cache_internal_ip' in hostvars[host] else hostvars[host]['ansible_host'] }}

--- a/partition/roles/pixiecore/README.md
+++ b/partition/roles/pixiecore/README.md
@@ -4,8 +4,9 @@ Deploys pixiecore in a systemd-managed Docker container.
 
 ## Variables
 
-| Name                 | Mandatory | Description                                                                                              |
-| -------------------- | --------- | -------------------------------------------------------------------------------------------------------- |
-| pixiecore_image_name | yes       | Image version of the pixiecore                                                                           |
-| pixiecore_image_tag  | yes       | Image tag of the pixiecore                                                                               |
-| pixiecore_api_url    |           | The url the pixiecore server uses in api mode for requesting the boot image. Should point to metal-core. |
+| Name                  | Mandatory | Description                                                                                                   |
+| --------------------- | --------- | ------------------------------------------------------------------------------------------------------------- |
+| pixiecore_image_name  | yes       | Image version of the pixiecore                                                                                |
+| pixiecore_image_tag   | yes       | Image tag of the pixiecore                                                                                    |
+| pixiecore_api_url     |           | The url the pixiecore server uses in api mode for requesting the boot image. Should point to metal-core.      |
+| pixiecore_dns_servers |           | Alternative DNS servers to be used by the pixiecore (can be used for configuring kernel and boot image cache) | 

--- a/partition/roles/pixiecore/defaults/main/main.yaml
+++ b/partition/roles/pixiecore/defaults/main/main.yaml
@@ -1,2 +1,3 @@
 ---
 pixiecore_api_url: http://localhost:4242
+pixiecore_dns_servers: []

--- a/partition/roles/pixiecore/tasks/main.yaml
+++ b/partition/roles/pixiecore/tasks/main.yaml
@@ -21,6 +21,7 @@
     systemd_docker_cpu_period: 50000
     systemd_docker_cpu_quota: 10000
     systemd_docker_memory: 256m
+    systemd_docker_dns: "{{ pixiecore_dns_servers | default(omit) }}"
     # Because Pixiecore needs to listen for DHCP traffic,
     # it has to run with access to the host's networking stack.
     # Both Rkt and Docker do this with the --net=host commandline flag.

--- a/partition/roles/pixiecore/tasks/main.yaml
+++ b/partition/roles/pixiecore/tasks/main.yaml
@@ -21,7 +21,7 @@
     systemd_docker_cpu_period: 50000
     systemd_docker_cpu_quota: 10000
     systemd_docker_memory: 256m
-    systemd_docker_dns: "{{ pixiecore_dns_servers | default(omit) }}"
+    systemd_docker_dns: "{{ pixiecore_dns_servers }}"
     # Because Pixiecore needs to listen for DHCP traffic,
     # it has to run with access to the host's networking stack.
     # Both Rkt and Docker do this with the --net=host commandline flag.


### PR DESCRIPTION
References https://github.com/metal-stack/metal-image-cache-sync/pull/6.

Depends on https://github.com/metal-stack/ansible-common/pull/12.

Breaking change:

**Changes the mount path for the image cache to support kernels and initrd boot images. After deployment, you should deleted all other folders from the cache's root folder except `images`, `kernels`, `boot-images`, `tmp`.**