### PR TITLE
Fix image cache kernel / boot-image fallback

### DIFF
--- a/partition/roles/image-cache/templates/haproxy.j2
+++ b/partition/roles/image-cache/templates/haproxy.j2
@@ -45,28 +45,30 @@ frontend images
 {% if image_cache_kernel_cache_enabled %}
   acl has_kernel_path_prefix path_beg {{ image_cache_kernel_route_prefix }}
   use_backend partition_local_kernel_cache if has_kernel_path_prefix
-  acl partition_local_kernel_cache_dead nbsrv(partition_local_kernel_cache) eq 0
-  use_backend global_kernel_store if has_kernel_path_prefix partition_local_kernel_cache_dead
+  # acl partition_local_kernel_cache_dead nbsrv(partition_local_kernel_cache) eq 0
+  # use_backend global_kernel_store if has_kernel_path_prefix partition_local_kernel_cache_dead
 {% endif %}
 
 {% if image_cache_boot_image_cache_enabled %}
   acl has_boot_image_path_prefix path_beg {{ image_cache_boot_image_route_prefix }}
   use_backend partition_local_boot_image_cache if has_boot_image_path_prefix
-  acl partition_local_boot_image_cache_dead nbsrv(partition_local_boot_image_cache) eq 0
-  use_backend global_boot_image_store if has_boot_image_path_prefix partition_local_boot_image_cache_dead
+  # acl partition_local_boot_image_cache_dead nbsrv(partition_local_boot_image_cache) eq 0
+  # use_backend global_boot_image_store if has_boot_image_path_prefix partition_local_boot_image_cache_dead
 {% endif %}
 
-  acl partition_local_image_cache_dead nbsrv(partition_local_image_cache) eq 0
-  use_backend global_image_store if partition_local_image_cache_dead
+  # acl partition_local_image_cache_dead nbsrv(partition_local_image_cache) eq 0
+  # use_backend global_image_store if partition_local_image_cache_dead
   default_backend partition_local_image_cache
 
 frontend images_passthrough
   mode tcp
-  bind :443
+  bind *:443
+
+  tcp-request inspect-delay 5s
+  tcp-request content accept if { req_ssl_hello_type 1 }
 
 {% for domain in image_cache_intercept_domains %}
-  acl has_sni_domain_{{ loop.index }} ssl_fc_sni {{ domain }}
-  use_backend global_https_passthrough_{{ loop.index }} if has_sni_domain_{{ loop.index }}
+  use_backend global_https_passthrough_{{ loop.index }} if  { req_ssl_sni -i {{ domain }} }
 {% endfor %}
 
 backend partition_local_image_cache

--- a/partition/roles/image-cache/templates/haproxy.j2
+++ b/partition/roles/image-cache/templates/haproxy.j2
@@ -37,6 +37,13 @@ resolvers pubdns
   nameserver {{ dns_server.name }} {{ dns_server.ip }}:53
 {% endfor %}
 
+  hold valid    60s
+  hold other    60s
+  hold refused  60s
+  hold nx       60s
+  hold timeout  60s
+  hold obsolete 60s
+
 frontend caches
   bind :80
   option forwardfor except 127.0.0.1

--- a/partition/roles/image-cache/templates/haproxy.j2
+++ b/partition/roles/image-cache/templates/haproxy.j2
@@ -45,19 +45,20 @@ frontend images
 {% if image_cache_kernel_cache_enabled %}
   acl has_kernel_path_prefix path_beg {{ image_cache_kernel_route_prefix }}
   use_backend partition_local_kernel_cache if has_kernel_path_prefix
-  # acl partition_local_kernel_cache_dead nbsrv(partition_local_kernel_cache) eq 0
-  # use_backend global_kernel_store if has_kernel_path_prefix partition_local_kernel_cache_dead
+  acl partition_local_kernel_cache_dead nbsrv(partition_local_kernel_cache) eq 0
+  http-request redirect scheme https if partition_local_kernel_cache_dead
 {% endif %}
 
 {% if image_cache_boot_image_cache_enabled %}
   acl has_boot_image_path_prefix path_beg {{ image_cache_boot_image_route_prefix }}
   use_backend partition_local_boot_image_cache if has_boot_image_path_prefix
-  # acl partition_local_boot_image_cache_dead nbsrv(partition_local_boot_image_cache) eq 0
-  # use_backend global_boot_image_store if has_boot_image_path_prefix partition_local_boot_image_cache_dead
+  acl partition_local_boot_image_cache_dead nbsrv(partition_local_boot_image_cache) eq 0
+  http-request redirect scheme https if partition_local_boot_image_cache_dead
 {% endif %}
 
-  # acl partition_local_image_cache_dead nbsrv(partition_local_image_cache) eq 0
-  # use_backend global_image_store if partition_local_image_cache_dead
+  acl partition_local_image_cache_dead nbsrv(partition_local_image_cache) eq 0
+  http-request redirect scheme https if partition_local_image_cache_dead
+
   default_backend partition_local_image_cache
 
 frontend images_passthrough
@@ -68,7 +69,7 @@ frontend images_passthrough
   tcp-request content accept if { req_ssl_hello_type 1 }
 
 {% for domain in image_cache_intercept_domains %}
-  use_backend global_https_passthrough_{{ loop.index }} if  { req_ssl_sni -i {{ domain }} }
+  use_backend global_https_passthrough_{{ loop.index }} if { req_ssl_sni -i {{ domain }} }
 {% endfor %}
 
 backend partition_local_image_cache
@@ -104,6 +105,7 @@ backend partition_local_boot_image_cache
 
 {% for domain in image_cache_intercept_domains %}
 backend global_https_passthrough_{{ loop.index }}
-  balance leastconn
-  server {{ domain }} {{ domain }}:443 ssl verify required ca-file ca-certificates.crt check inter 30s rise 2 fall 3 resolvers pubdns resolve-prefer ipv4
+  mode tcp
+  server {{ domain }} {{ domain}}:443
+
 {% endfor %}

--- a/partition/roles/image-cache/templates/haproxy.j2
+++ b/partition/roles/image-cache/templates/haproxy.j2
@@ -64,32 +64,10 @@ frontend images_passthrough
   mode tcp
   bind :443
 
-{% if image_cache_kernel_cache_enabled %}
-  acl has_kernel_path_prefix path_beg {{ image_cache_kernel_route_prefix }}
-  use_backend global_kernel_store_passthrough if has_kernel_path_prefix
-{% endif %}
-{% if image_cache_boot_image_cache_enabled %}
-  acl has_boot_image_path_prefix path_beg {{ image_cache_boot_image_route_prefix }}
-  use_backend global_boot_image_store_passthrough if has_boot_image_path_prefix
-{% endif %}
-
-  default_backend global_image_store_passthrough
-
-backend global_image_store_passthrough
-  mode tcp
-  server {{ image_cache_haproxy_fallback_backend_server }} {{ image_cache_haproxy_fallback_backend_server }}:443
-
-{% if image_cache_kernel_cache_enabled %}
-backend global_kernel_store_passthrough
-  mode tcp
-  server {{ image_cache_haproxy_kernel_fallback_backend_server }} {{ image_cache_haproxy_kernel_fallback_backend_server }}:443
-{% endif %}
-
-{% if image_cache_boot_image_cache_enabled %}
-backend global_boot_image_store_passthrough
-  mode tcp
-  server {{ image_cache_haproxy_boot_image_fallback_backend_server }} {{ image_cache_haproxy_boot_image_fallback_backend_server }}:443
-{% endif %}
+{% for domain in image_cache_intercept_domains %}
+  acl has_sni_domain_{{ loop.index }} ssl_fc_sni {{ domain }}
+  use_backend global_https_passthrough_{{ loop.index }} if has_sni_domain_{{ loop.index }}
+{% endfor %}
 
 backend partition_local_image_cache
   option httpchk
@@ -122,30 +100,8 @@ backend partition_local_boot_image_cache
 {% endfor %}
 {% endif %}
 
-backend global_image_store
-  option httpchk
-  http-check send meth GET uri {{ image_cache_haproxy_fallback_backend_server_health_endpoint }} ver HTTP/1.1 hdr host {{ image_cache_haproxy_fallback_backend_server }}
-  http-check expect status 200
+{% for domain in image_cache_intercept_domains %}
+backend global_https_passthrough_{{ loop.index }}
   balance leastconn
-  http-request set-header Host {{ image_cache_haproxy_fallback_backend_server }}
-  server {{ image_cache_haproxy_fallback_backend_server }} {{ image_cache_haproxy_fallback_backend_server }}:443 ssl verify required ca-file ca-certificates.crt check inter 30s rise 2 fall 3 resolvers pubdns resolve-prefer ipv4
-
-{% if image_cache_kernel_cache_enabled %}
-backend global_kernel_store
-  option httpchk
-  http-check send meth GET uri {{ image_cache_haproxy_kernel_fallback_backend_server_health_endpoint }} ver HTTP/1.1 hdr host {{ image_cache_haproxy_kernel_fallback_backend_server }}
-  http-check expect status 200
-  balance leastconn
-  http-request set-header Host {{ image_cache_haproxy_kernel_fallback_backend_server }}
-  server {{ image_cache_haproxy_kernel_fallback_backend_server }} {{ image_cache_haproxy_kernel_fallback_backend_server }}:443 ssl verify required ca-file ca-certificates.crt check inter 30s rise 2 fall 3 resolvers pubdns resolve-prefer ipv4
-{% endif %}
-
-{% if image_cache_boot_image_cache_enabled %}
-backend global_boot_image_store
-  option httpchk
-  http-check send meth GET uri {{ image_cache_haproxy_boot_image_fallback_backend_server_health_endpoint }} ver HTTP/1.1 hdr host {{ image_cache_haproxy_boot_image_fallback_backend_server }}
-  http-check expect status 200
-  balance leastconn
-  http-request set-header Host {{ image_cache_haproxy_boot_image_fallback_backend_server }}
-  server {{ image_cache_haproxy_boot_image_fallback_backend_server }} {{ image_cache_haproxy_boot_image_fallback_backend_server }}:443 ssl verify required ca-file ca-certificates.crt check inter 30s rise 2 fall 3 resolvers pubdns resolve-prefer ipv4
-{% endif %}
+  server {{ domain }} {{ domain }}:443 ssl verify required ca-file ca-certificates.crt check inter 30s rise 2 fall 3 resolvers pubdns resolve-prefer ipv4
+{% endfor %}

--- a/partition/roles/image-cache/templates/haproxy.j2
+++ b/partition/roles/image-cache/templates/haproxy.j2
@@ -37,7 +37,7 @@ resolvers pubdns
   nameserver {{ dns_server.name }} {{ dns_server.ip }}:53
 {% endfor %}
 
-frontend images
+frontend caches
   bind :80
   option forwardfor except 127.0.0.1
   option forwardfor header X-Real-IP
@@ -61,7 +61,7 @@ frontend images
 
   default_backend partition_local_image_cache
 
-frontend images_passthrough
+frontend https_passthrough
   mode tcp
   bind *:443
 


### PR DESCRIPTION
Currently, the fallback to the internet does not work properly because `path_beg` is used inside the HTTPS frontend (which does not work of course because paths are encrypted).

The new approach uses SNI to make the routing decision to the backend.