### PR TITLE
Enable updating Jinja2 by assembling size entities manually in values.

### DIFF
--- a/control-plane/roles/metal/templates/metal-values.j2
+++ b/control-plane/roles/metal/templates/metal-values.j2
@@ -104,7 +104,19 @@ metal_api:
   sizes: |
 {% for entity in metal_api_sizes %}
     ---
+{# the byte sizes from humanfriendly are always casted to strings with latest Ansible and jinja2 versions (even with native env enabled) #}
+{# behaviour seems to be expected, so there we convert min/max fields manually here and assemble the entity #}
+{# https://github.com/ansible/ansible/issues/74980 #}
+{% set constraints=entity.pop('constraints') %}
     {{ entity | to_nice_yaml | indent(width=4, first=false) }}
+    constraints:
+{% for constraint in constraints %}
+{% set min=constraint.pop('min') %}
+{% set max=constraint.pop('max') %}
+    - min: {{ min }}
+      max: {{ max }}
+      {{ constraint | to_nice_yaml | indent(width=6, first=false) }}
+{% endfor %}
 {% endfor %}
   images: |
 {% for entity in metal_api_images %}


### PR DESCRIPTION
We have just a single point that prevents us updating Jinja2 to the latest version + Ansible to latest version. It's when in the group_vars we use the humanfriendly filter, which Jinja2 returns always as strings. This is a workaround of this problem and then enables https://github.com/metal-stack/metal-dockerfiles/pull/18.