### PR TITLE
Fix default auth for docker.io

### DIFF
--- a/control-plane/roles/ipam-db/defaults/main/main.yaml
+++ b/control-plane/roles/ipam-db/defaults/main/main.yaml
@@ -34,7 +34,7 @@ ipam_db_resources:
 ipam_db_registry_auth_enabled: "{{ metal_registry_auth_enabled }}"
 ipam_db_registry_auth:
   auths:
-    docker.io:
+    https://index.docker.io/v1/:
       username: "{{ metal_registry_auth_user }}"
       password: "{{ metal_registry_auth_password }}"
       auth: "{{ (metal_registry_auth_user + ':' + metal_registry_auth_password) | b64encode }}"

--- a/control-plane/roles/masterdata-db/defaults/main/main.yaml
+++ b/control-plane/roles/masterdata-db/defaults/main/main.yaml
@@ -34,7 +34,7 @@ masterdata_db_resources:
 masterdata_db_registry_auth_enabled: "{{ metal_registry_auth_enabled }}"
 masterdata_db_registry_auth:
   auths:
-    docker.io:
+    https://index.docker.io/v1/:
       username: "{{ metal_registry_auth_user }}"
       password: "{{ metal_registry_auth_password }}"
       auth: "{{ (metal_registry_auth_user + ':' + metal_registry_auth_password) | b64encode }}"

--- a/control-plane/roles/metal-db/defaults/main/main.yaml
+++ b/control-plane/roles/metal-db/defaults/main/main.yaml
@@ -34,7 +34,7 @@ metal_db_resources:
 metal_db_registry_auth_enabled: "{{ metal_registry_auth_enabled }}"
 metal_db_registry_auth:
   auths:
-    docker.io:
+    https://index.docker.io/v1/:
       username: "{{ metal_registry_auth_user }}"
       password: "{{ metal_registry_auth_password }}"
       auth: "{{ (metal_registry_auth_user + ':' + metal_registry_auth_password) | b64encode }}"

--- a/control-plane/roles/nsq/defaults/main/main.yaml
+++ b/control-plane/roles/nsq/defaults/main/main.yaml
@@ -31,7 +31,7 @@ nsq_certs_ca_cert:
 nsq_registry_auth_enabled: "{{ metal_registry_auth_enabled }}"
 nsq_registry_auth:
   auths:
-    docker.io:
+    https://index.docker.io/v1/:
       username: "{{ metal_registry_auth_user }}"
       password: "{{ metal_registry_auth_password }}"
       auth: "{{ (metal_registry_auth_user + ':' + metal_registry_auth_password) | b64encode }}"

--- a/control-plane/roles/postgres-backup-restore/defaults/main/main.yaml
+++ b/control-plane/roles/postgres-backup-restore/defaults/main/main.yaml
@@ -40,7 +40,7 @@ postgres_resources:
 postgres_registry_auth_enabled: "{{ metal_registry_auth_enabled }}"
 postgres_registry_auth:
   auths:
-    docker.io:
+    https://index.docker.io/v1/:
       username: "{{ metal_registry_auth_user }}"
       password: "{{ metal_registry_auth_password }}"
       auth: "{{ (metal_registry_auth_user + ':' + metal_registry_auth_password) | b64encode }}"

--- a/control-plane/roles/rethinkdb-backup-restore/defaults/main/main.yaml
+++ b/control-plane/roles/rethinkdb-backup-restore/defaults/main/main.yaml
@@ -34,7 +34,7 @@ rethinkdb_resources:
 rethinkdb_registry_auth_enabled: "{{ metal_registry_auth_enabled }}"
 rethinkdb_registry_auth:
   auths:
-    docker.io:
+    https://index.docker.io/v1/:
       username: "{{ metal_registry_auth_user }}"
       password: "{{ metal_registry_auth_password }}"
       auth: "{{ (metal_registry_auth_user + ':' + metal_registry_auth_password) | b64encode }}"


### PR DESCRIPTION
Somehow the registry with plain "docker.io" does not work anymore, also on Docker websites they use index.docker.io.

https://docs.docker.com/engine/reference/commandline/login/#credential-helper-protocol