### PR TITLE
Raise metal-core memory to 1G.

### DIFF
--- a/partition/roles/metal-core/tasks/main.yaml
+++ b/partition/roles/metal-core/tasks/main.yaml
@@ -68,7 +68,7 @@
     systemd_service_timeout_start_sec: 60
     systemd_docker_cpu_period: 50000
     systemd_docker_cpu_quota: 10000
-    systemd_docker_memory: 256m
+    systemd_docker_memory: 1024m
     # metal-core needs to figure out the switch ports, this is only possible from host network
     systemd_docker_network: host
     systemd_docker_volumes: "{{ lookup('template', 'metal-core-volumes.j2') | from_yaml }}"


### PR DESCRIPTION
Required for firmware update to run.

References https://github.com/metal-stack/metal-core/pull/38.