### PR TITLE
Add option to install metal-python from the git repository.

### DIFF
--- a/control-plane/roles/metal-python/README.md
+++ b/control-plane/roles/metal-python/README.md
@@ -10,11 +10,12 @@ None
 
 ## Variables
 
-| Name                                         | Mandatory | Description                                                                  |
-| -------------------------------------------- | --------- | ---------------------------------------------------------------------------- |
-| metal_python_version                         |           | The specific metal-python version to install.                                |
-| metal_python_version_from_release_vector     |           | Attempts to derive fitting metal-python version from release vector          |
-| metal_python_install_latest_on_version_error |           | Whether to just install latest metal-python when given version was not found |
+| Name                                         | Mandatory | Description                                                                               |
+| -------------------------------------------- | --------- | ----------------------------------------------------------------------------------------- |
+| metal_python_version                         |           | The specific metal-python version to install.                                             |
+| metal_python_version_from_release_vector     |           | Attempts to derive fitting metal-python version from release vector                       |
+| metal_python_install_latest_on_version_error |           | Whether to just install latest metal-python when given version was not found              |
+| metal_python_install_from_git_repository     |           | Alternatively, install directly from the git repository (e.g. for testing a devel branch) |
 
 ## Examples
 
@@ -28,4 +29,11 @@ None
     name: metal-roles/control-plane/roles/metal-python
   vars:
     metal_python_version: "0.10.0"
+
+- name: Install metal-python devel branch
+  include_role:
+    name: metal-roles/control-plane/roles/metal-python
+  vars:
+    metal_python_version: "my-nice-feature"
+    metal_python_install_from_git_repository: yes
 ```

--- a/control-plane/roles/metal-python/defaults/main.yaml
+++ b/control-plane/roles/metal-python/defaults/main.yaml
@@ -2,3 +2,4 @@
 metal_python_version:
 metal_python_version_from_release_vector: yes
 metal_python_install_latest_on_version_error: yes
+metal_python_install_from_git_repository: no

--- a/control-plane/roles/metal-python/tasks/main.yaml
+++ b/control-plane/roles/metal-python/tasks/main.yaml
@@ -23,8 +23,13 @@
   block:
     - name: Install metal-python {{ metal_python_version }}
       pip:
-        name:
-          - metal_python=={{ metal_python_version }}
+        name: metal_python=={{ metal_python_version }}
+      when: not metal_python_install_from_git_repository | bool
+
+    - name: Install metal-python {{ metal_python_version }} from git repository
+      pip:
+        name: git+https://github.com/metal-stack/metal-python.git@{{ metal_python_version }}
+      when: metal_python_install_from_git_repository | bool
 
   rescue:
     # attempt with latest available client when fitting client is not available


### PR DESCRIPTION
Found this use-case in one of our playbooks while adding the new metal-python role to them.