### PR TITLE
Use default mem-queue-size for NSQd.

### DIFF
--- a/control-plane/roles/nsq/templates/nsq.yaml
+++ b/control-plane/roles/nsq/templates/nsq.yaml
@@ -47,7 +47,6 @@ spec:
         - -log-level={{ nsq_log_level }}
         - -lookupd-tcp-address=nsq-lookupd:4160
         - -broadcast-address={{ nsq_broadcast_address }}
-        - -mem-queue-size=0
         - -data-path=/data
 {% if nsq_tls_enabled %}
         - -tls-required=tcp-https


### PR DESCRIPTION
Since updating to nsq v1.2.1 we do not see any messages consumed by clients anymore for ephemeral streams.

This could be introduced by the following changes introduced by v1.2.1 in combination with our `--mem-queue-size=0` setting:
- https://github.com/nsqio/nsq/pull/1159
- https://github.com/nsqio/nsq/pull/1376

We should just use the default setting again. After that, messages are delivered to the clients as before.