### PR TITLE
Remove ingress service exposal tasks.

### DIFF
--- a/control-plane/README.md
+++ b/control-plane/README.md
@@ -5,7 +5,15 @@ Contains roles for deploying the metal-control-plane.
 ## Requirements
 
 - [ansible-common](https://github.com/metal-stack/ansible-common)
-- an ingress-controller in your cluster ([nginx-ingress](https://github.com/kubernetes/ingress-nginx) is the default of this project, you need to parametrize the roles carefully if you want to use another ingress-controller. when you just use nginx-ingress, make sure to also deploy it to the default namespace `ingress-nginx`)
+- an ingress-controller in your cluster ([nginx-ingress](https://github.com/kubernetes/ingress-nginx) is the default of this project)
+- As our control plane also requires layer-4 services to be exposed to the outside world, you need to take care of exposing them in order to make them reachable from a partition. This can for instance be achieved through [tcp and udp service exposal of Kubernetes nginx-ingress](https://kubernetes.github.io/ingress-nginx/user-guide/exposing-tcp-udp-services/). You can look up how it can be done in the [mini-lab](https://github.com/metal-stack/mini-lab). Here comes the list of required ports:
+
+    | Port  | Protocol | Service Name  | Description                   |
+    | ----- | -------- | ------------- | ----------------------------- |
+    | 4150  | TCP      | nsqd          | nsq Daemon (HTTPS)            |
+    | 4161  | TCP      | nsq-lookupd   | nsqlookup Damon (HTTP)        |
+    | 5222  | TCP      | metal-console | Console forwarding (SSH)      |
+    | 50051 | TCP      | metal-api     | metal-api gRPC API (protobuf) |
 
 ## Variables
 

--- a/control-plane/roles/metal/README.md
+++ b/control-plane/roles/metal/README.md
@@ -2,8 +2,6 @@
 
 This role basically deploys the `metal-control-plane` [helm chart](https://github.com/metal-stack/helm-charts/tree/master/charts/metal-control-plane). It uses [hooks](https://github.com/helm/helm/blob/master/docs/charts_hooks.md) to deploy the control plane. There is a post-install hook to initialize the rethinkdb tables (there would be race conditions if there are multiple metal-api replicas initializing the database at the same time). Then, there are post-install and post-upgrade hooks to initialize and update the "masterdata" of the control plane (e.g. images, partitions, networks in this control plane).
 
-As our control plane also requires non-HTTP ports to be exposed to the outside world, we currently use [tcp and udp service exposal of Kubernetes nginx-ingress](https://kubernetes.github.io/ingress-nginx/user-guide/exposing-tcp-udp-services/).
-
 ## Variables
 
 This role uses variables from [control-plane-defaults](/control-plane). So, make sure you define them adequately as well.
@@ -14,7 +12,6 @@ You can look up all the default values of this role [here](defaults/main/main.ya
 
 | Name                               | Mandatory | Description                                                                                                                        |
 |------------------------------------|-----------|------------------------------------------------------------------------------------------------------------------------------------|
-| metal_expose_ingress_service_ports |           | Exposes tcp and udp services over nginx-ingress, requires [nginx-ingress](https://github.com/kubernetes/ingress-nginx) to be setup |
 | metal_check_api_available          |           | Checks whether the metal-api is reachable from the outside after deployment                                                        |
 | metal_check_api_health_endpoint    |           | The endpoint to call if the metal-api is reachable from the outside after deployment                                               |
 | metal_set_resource_limits          |           | Deploys metal components with or without resource limits (possibly disable for development environments)                           |

--- a/control-plane/roles/metal/defaults/main/main.yaml
+++ b/control-plane/roles/metal/defaults/main/main.yaml
@@ -1,5 +1,4 @@
 ---
-metal_expose_ingress_service_ports: yes
 metal_check_api_available: yes
 
 metal_helm_chart_local_path:

--- a/control-plane/roles/metal/tasks/main.yaml
+++ b/control-plane/roles/metal/tasks/main.yaml
@@ -39,54 +39,6 @@
     helm_timeout: "{{ metal_helm_chart_timeout }}"
     helm_chart_inject_config_hash: yes
 
-- name: Set services for patching ingress controller service exposal
-  set_fact:
-    metal_tcp_services:
-      "5222": "{{ metal_control_plane_namespace }}/metal-console:10001"
-      "50051": "{{ metal_control_plane_namespace }}/metal-api:50051"
-    metal_udp_services:
-      "5222": "{{ metal_control_plane_namespace }}/metal-console:10001"
-  when: metal_expose_ingress_service_ports
-
-- name: Patch tcp-services in ingress controller
-  k8s:
-    api_version: v1
-    kind: ConfigMap
-    namespace: ingress-nginx
-    name: tcp-services
-    definition:
-      data: "{{ lookup('k8s', api_version='v1', kind='ConfigMap', namespace='ingress-nginx', resource_name='tcp-services').get('data', {}) | combine(metal_tcp_services) }}"
-  when: metal_expose_ingress_service_ports
-
-- name: Patch udp-services in ingress controller
-  k8s:
-    api_version: v1
-    kind: ConfigMap
-    namespace: ingress-nginx
-    name: udp-services
-    definition:
-      data: "{{ lookup('k8s', api_version='v1', kind='ConfigMap', namespace='ingress-nginx', resource_name='udp-services').get('data', {}) | combine(metal_udp_services) }}"
-  when: metal_expose_ingress_service_ports
-
-- name: Expose tcp services in ingress controller
-  k8s:
-    api_version: v1
-    kind: Service
-    namespace: ingress-nginx
-    name: ingress-nginx
-    definition:
-      spec:
-        ports:
-        - name: metal-control-plane-console
-          port: 5222
-          protocol: TCP
-          targetPort: 5222
-        - name: metal-control-plane-grpc
-          port: 50051
-          protocol: TCP
-          targetPort: 50051
-  when: metal_expose_ingress_service_ports
-
 # for automation tests, we need to wait until all the services are ready...
 - name: Wait until api is available
   uri:

--- a/control-plane/roles/nsq/README.md
+++ b/control-plane/roles/nsq/README.md
@@ -10,8 +10,6 @@ kubectl port-forward -n metal-control-plane svc/nsqadmin 4171
 
 Adding nsqadmin as a sidecar into the nsqd pod was the only reasonable way to make the admin console work properly in this setup. This is because we enforce certificate authentication via the TCP port but do not use encrypted communication for in-cluster traffic via the HTTP endpoints, which nsadmin does not really like.
 
-As our control plane also requires non-HTTP ports to be exposed to the outside world, we currently use [tcp and udp service exposal of Kubernetes nginx-ingress](https://kubernetes.github.io/ingress-nginx/user-guide/exposing-tcp-udp-services/).
-
 ## Variables
 
 This role uses variables from [control-plane-defaults](/control-plane). So, make sure you define them adequately as well.
@@ -22,7 +20,6 @@ You can look up all the default values of this role [here](defaults/main/main.ya
 | -------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | nsq_image_name                   | yes       | Image name of nsq                                                                                                                  |
 | nsq_image_tag                    | yes       | Image version of nsq                                                                                                               |
-| nsq_expose_ingress_service_ports |           | Exposes tcp and udp services over nginx-ingress, requires [nginx-ingress](https://github.com/kubernetes/ingress-nginx) to be setup |
 | nsq_set_resource_limits          |           | Deploys nsq with or without resource limits (possibly disable for development environments)                                        |
 | nsq_nsqd_resources               |           | The kubernetes resources for the actual nsqd container                                                                             |
 | nsq_nsq_lookupd_resources        |           | The kubernetes resources for the actual nsq lookupd container                                                                      |
@@ -33,4 +30,4 @@ You can look up all the default values of this role [here](defaults/main/main.ya
 | nsq_certs_client_key             |           | The nsq certificate client key as a string                                                                                         |
 | nsq_certs_client_cert            |           | The nsq client certificate as a string                                                                                             |
 | nsq_certs_ca_cert                |           | The nsq ca certificate as a string                                                                                                 |
-| nsq_image_pull_policy            |           | Image pull policy (defaults to IfNotPresent)                                                                                       | 
+| nsq_image_pull_policy            |           | Image pull policy (defaults to IfNotPresent)                                                                                       |

--- a/control-plane/roles/nsq/defaults/main/main.yaml
+++ b/control-plane/roles/nsq/defaults/main/main.yaml
@@ -1,6 +1,4 @@
 ---
-nsq_expose_ingress_service_ports: yes
-
 nsq_image_pull_policy: "{{ metal_control_plane_image_pull_policy }}"
 
 nsq_set_resource_limits: true

--- a/control-plane/roles/nsq/tasks/main.yaml
+++ b/control-plane/roles/nsq/tasks/main.yaml
@@ -15,38 +15,3 @@
     definition: "{{ lookup('template', 'nsq.yaml') }}"
     namespace: "{{ metal_control_plane_namespace }}"
 
-- name: Set services for patching ingress controller service exposal
-  set_fact:
-    nsq_tcp_services:
-      "4161": "{{ metal_control_plane_namespace }}/nsq-lookupd:4161"
-      "4150": "{{ metal_control_plane_namespace }}/nsqd:4150"
-  when: nsq_expose_ingress_service_ports
-
-- name: Patch tcp-services in ingress controller
-  k8s:
-    api_version: v1
-    kind: ConfigMap
-    namespace: ingress-nginx
-    name: tcp-services
-    definition:
-      data: "{{ lookup('k8s', api_version='v1', kind='ConfigMap', namespace='ingress-nginx', resource_name='tcp-services').get('data', {}) | combine(nsq_tcp_services) }}"
-  when: nsq_expose_ingress_service_ports
-
-- name: Expose tcp services in ingress controller
-  k8s:
-    api_version: v1
-    kind: Service
-    namespace: ingress-nginx
-    name: ingress-nginx
-    definition:
-      spec:
-        ports:
-        - name: nsq-lookupd
-          port: 4161
-          protocol: TCP
-          targetPort: 4161
-        - name: nsqd
-          port: 4150
-          protocol: TCP
-          targetPort: 4150
-  when: nsq_expose_ingress_service_ports


### PR DESCRIPTION
Closes #77.

```BREAKING_CHANGE
Maintainers: The tasks for layer-4 service exposal are removed from the deployment automation and it is required to do this through the deployment of your ingress-controller by now. If necessary, you can look up how it can be done in the [mini-lab](https://github.com/metal-stack/mini-lab).
```