### PR TITLE
Move to ingress api version to networking.k8s.io/v1.

### DIFF
--- a/control-plane/roles/rethinkdb-backup-restore/templates/rethinkdb.yaml
+++ b/control-plane/roles/rethinkdb-backup-restore/templates/rethinkdb.yaml
@@ -232,7 +232,7 @@ data:
 {% endif %}
 {% if rethinkdb_expose_frontend %}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ rethinkdb_name }}
@@ -246,7 +246,10 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: {{ rethinkdb_name }}
-          servicePort: 10080
+          service:
+            name: {{ rethinkdb_name }}
+            port:
+              number: 10080
 {% endif %}


### PR DESCRIPTION
```ACTIONS_REQUIRED
The ingress resource has moved to API Version networking.k8s.io/v1. Make sure you have at least Kubernetes 1.19 installed in order to support this version.
```