### PR TITLE
Add missing ingress-class for rethinkDB mini-lab exposal.

### DIFF
--- a/control-plane/roles/rethinkdb-backup-restore/templates/rethinkdb.yaml
+++ b/control-plane/roles/rethinkdb-backup-restore/templates/rethinkdb.yaml
@@ -237,7 +237,7 @@ kind: Ingress
 metadata:
   name: {{ rethinkdb_name }}
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:


### PR DESCRIPTION
Now the frontend is reachable again on http://rethinkdb.172.17.0.1.nip.io:8080/ for the mini-lab.