### PR TITLE
increment headscale retries

### DIFF
--- a/control-plane/roles/headscale/tasks/main.yaml
+++ b/control-plane/roles/headscale/tasks/main.yaml
@@ -65,7 +65,7 @@
 - name: Wait until headscale deployment is ready
   command: echo
   changed_when: false
-  retries: 10
+  retries: 20
   delay: 12
   when: not headscale_api_key_already_created
   until:


### PR DESCRIPTION
Incremented Headscale start retries, otherwise mini-lab often fails with time outs.