### PR TITLE
Make deployment of headscale compatible with >= v0.17

### DIFF
--- a/control-plane/roles/headscale/README.md
+++ b/control-plane/roles/headscale/README.md
@@ -19,6 +19,7 @@ The role should take the same variables as the wrapped role, but prefixed with `
 | headscale_db_backup_restore_sidecar_image_name | yes       | Image name of init container for headscale DB               |
 | headscale_db_backup_restore_sidecar_image_tag  | yes       | Image version of init container for headscale DB            |
 | headscale_private_key                          | yes       | Private key                                                 |
+| headscale_noise_private_key                    | yes       | Noise Protocol Private key for TS2021 compatibility         |
 | headscale_ingress_dns                          |           | Domain name                                                 |
 | headscale_namespace                            |           | The deployment's target namespace                           |
 | headscale_tls                                  |           | Enables TLS for headscale                                   |

--- a/control-plane/roles/headscale/README.md
+++ b/control-plane/roles/headscale/README.md
@@ -11,7 +11,7 @@ If you want to rotate the API key, you need to delete the `headscale-api-key` se
 The role should take the same variables as the wrapped role, but prefixed with `headscale_db_` instead of `postgres_`.
 
 | Name                                           | Mandatory | Description                                                 |
-| ---------------------------------------------- | --------- | ----------------------------------------------------------- |
+|------------------------------------------------|-----------|-------------------------------------------------------------|
 | headscale_image_name                           | yes       | Image name of headscale                                     |
 | headscale_image_tag                            | yes       | Image version of headscale                                  |
 | headscale_db_image_name                        | yes       | Image name of headscale DB                                  |
@@ -26,3 +26,4 @@ The role should take the same variables as the wrapped role, but prefixed with `
 | headscale_ingress_annotations                  |           | Annotations that will be attached to the ingress resource   |
 | headscale_resources                            |           | The kubernetes resources for the actual headscale container |
 | headscale_api_key_expiration                   |           | The time how long the generated api key will be valid       |
+| headscale_ip_prefixes                          |           | Slice of IP Prefixes where the tunnel endpoints are created |

--- a/control-plane/roles/headscale/defaults/main/main.yaml
+++ b/control-plane/roles/headscale/defaults/main/main.yaml
@@ -14,3 +14,7 @@ headscale_resources:
     memory: 200M
 
 headscale_api_key_expiration: 365d
+
+headscale_ip_prefixes:
+  - fd7a:115c:a1e0::/48
+  - 100.64.0.0/1

--- a/control-plane/roles/headscale/tasks/main.yaml
+++ b/control-plane/roles/headscale/tasks/main.yaml
@@ -14,6 +14,7 @@
       - headscale_db_backup_restore_sidecar_image_name is defined
       - headscale_db_backup_restore_sidecar_image_tag is defined
       - headscale_private_key is defined
+      - headscale_noise_private_key is defined
       - headscale_ingress_dns is not none
 
 - name: Create namespace for headscale

--- a/control-plane/roles/headscale/templates/headscale.yaml
+++ b/control-plane/roles/headscale/templates/headscale.yaml
@@ -12,6 +12,8 @@ data:
     grpc_allow_insecure: true
     ephemeral_node_inactivity_timeout: 30m
     private_key_path: /vol/data/private.key
+    noise:
+      private_key_path: /vol/data/noise_private.key
     derp:
       urls:
         - https://controlplane.tailscale.com/derpmap/default
@@ -29,6 +31,7 @@ type: Opaque
 data:
   # can be generated with headscale generate private-key | base64
   private.key: {{ headscale_private_key | b64encode }}
+  noise_private.key: {{ headscale_noise_private_key | b64encode }}
 ---
 apiVersion: v1
 stringData:

--- a/control-plane/roles/headscale/templates/headscale.yaml
+++ b/control-plane/roles/headscale/templates/headscale.yaml
@@ -17,6 +17,7 @@ data:
     derp:
       urls:
         - https://controlplane.tailscale.com/derpmap/default
+    ip_prefixes: {{ headscale_ip_prefixes | to_json }}
 
     db_type: postgres
     db_host: headscale-db


### PR DESCRIPTION
closes #106 and #104 

tested in fra-equ01 as well