### PR TITLE
Provide ztp role.

### DIFF
--- a/partition/roles/ztp/README.md
+++ b/partition/roles/ztp/README.md
@@ -1,0 +1,14 @@
+# ztp
+
+Configures a server for providing zero-touch-provisioning scripts for switches.
+
+## Variables
+
+| Name                | Mandatory | Description                                                 |
+| ------------------- | --------- | ----------------------------------------------------------- |
+| ztp_image_name      |           | the docker image to use to serve ztp scripts.               |
+| ztp_image_tag       |           | the tag of the docker image to use to serve ztp scripts.    |
+| ztp_host_dir_path   |           | the path to serve ztp scripts from.                         |
+| ztp_port            |           | the port to serve ztp scripts on.                           |
+| ztp_authorized_keys | yes       | the authorized keys that should be installed by ztp.        |
+| ztp_admin_user      |           | the user for which the authorized keys will be provisioned. |

--- a/partition/roles/ztp/defaults/main.yaml
+++ b/partition/roles/ztp/defaults/main.yaml
@@ -1,0 +1,10 @@
+---
+ztp_image_name: nginx
+ztp_image_tag: alpine
+
+ztp_host_dir_path: /ztp
+
+ztp_authorized_keys:
+ztp_admin_user: admin
+
+ztp_port: 8080

--- a/partition/roles/ztp/tasks/main.yaml
+++ b/partition/roles/ztp/tasks/main.yaml
@@ -1,0 +1,32 @@
+---
+- name: Check mandatory variables for this role are set
+  assert:
+    fail_msg: "not all mandatory variables given, check role documentation"
+    quiet: yes
+    that:
+      - ztp_authorized_keys is not none
+
+- name: create ztp config directory
+  file:
+    path: "{{ ztp_host_dir_path }}/config"
+    state: directory
+
+- name: render ztp script
+  template:
+    src: "ztp.sh.j2"
+    dest: "{{ ztp_host_dir_path }}/config/ztp.sh"
+    mode: 0644
+
+- name: deploy server for serving ztp.sh
+  include_role:
+    name: ansible-common/roles/systemd-docker-service
+  vars:
+    systemd_service_name: ztp-server
+    systemd_docker_image_name: "{{ ztp_image_name }}"
+    systemd_docker_image_tag: "{{ ztp_image_tag }}"
+    systemd_service_timeout_start_sec: 60
+    systemd_docker_volumes:
+      - "{{ ztp_host_dir_path }}/config:/var/www/html"
+    systemd_docker_ports:
+      - host_port: "{{ ztp_port }}"
+        target_port: "80"

--- a/partition/roles/ztp/templates/ztp.sh.j2
+++ b/partition/roles/ztp/templates/ztp.sh.j2
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+function error() {
+  echo -e "\\e[0;33mERROR: The Zero Touch Provisioning script failed while running the command \$BASH_COMMAND at line \$BASH_LINENO.\e[0m" >&2
+}
+
+# Log all output from this script
+#
+exec >> /var/log/autoprovision 2>&1
+date "+%FT%T ztp starting script $0"
+trap error ERR
+
+echo "authorize login for metal admins via management servers and login for Ansible deployments"
+mkdir -p /home/{{ ztp_admin_user }}/.ssh
+echo "{{ ztp_authorized_keys | join('\n') }}" >> /home/{{ ztp_admin_user }}/.ssh/authorized_keys
+chmod 700 -R /home/{{ ztp_admin_user }}/.ssh
+chown {{ ztp_admin_user }}:{{ ztp_admin_user }} -R /home/{{ ztp_admin_user }}/.ssh
+
+# The script must return an exit code of 0 upon success, as this triggers the autoprovisioning process to be marked as complete in the autoprovisioning configuration file.
+exit 0


### PR DESCRIPTION
This PR adds a ztp role to be used for adding an nginx to the management-server that serves a `ztp.sh` for zero-touch provisioning.

The work on this PR started in https://github.com/metal-stack/metal-roles/pull/112.