### PR TITLE
Allow metal-core deployment on SONiC.

### DIFF
--- a/partition/roles/metal-core/README.md
+++ b/partition/roles/metal-core/README.md
@@ -2,6 +2,8 @@
 
 Deploys metal-core in a systemd-managed Docker container.
 
+This role can deploy on switches running Cumulus Linux or SONiC. It depends on the `switch_facts` module from `ansible-common`, so make sure modules from `ansible-common` are included before executing this role.
+
 ## Variables
 
 This role uses variables from [partition-defaults](/partition). So, make sure you define them adequately as well.
@@ -9,10 +11,11 @@ This role uses variables from [partition-defaults](/partition). So, make sure yo
 You can look up all the default values of this role [here](defaults/main/main.yaml).
 
 | Name                                      | Mandatory | Description                                                                                                                                                                |
-|-------------------------------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----------------------------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | metal_core_image_name                     | yes       | Image name of metal-core                                                                                                                                                   |
 | metal_core_image_tag                      | yes       | Image tag of metal-core                                                                                                                                                    |
 | metal_core_cidr                           |           |                                                                                                                                                                            |
+| metal_core_dhcp_servers                   |           | List of dhcp relay server ip addresses                                                                                                                                     |
 | metal_core_log_level                      |           | The metal-core log level                                                                                                                                                   |
 | metal_core_rack_id                        | yes       | The rack id describing the rack in which the leaf switches are contained. Can be a logical rack name and is used by the metal-api to identify the switch pair              |
 | metal_core_reconfigure_switch             |           | If set to true, metal-core will automatically reconfigure files on the switch                                                                                              |

--- a/partition/roles/metal-core/tasks/main.yaml
+++ b/partition/roles/metal-core/tasks/main.yaml
@@ -2,6 +2,9 @@
 - name: Gather release versions
   setup_yaml:
 
+- name: Gather switch facts
+  switch_facts:
+
 - name: Check mandatory variables for this role are set
   assert:
     fail_msg: "not all mandatory variables given, check role documentation"
@@ -21,7 +24,7 @@
     dest: "{{ metal_core_grpc_cert_dir }}/{{ item.filename }}"
     mode: 0640
     content: "{{ item.content }}"
-  no_log: yes
+  no_log: true
   loop:
     - filename: ca.pem
       content: "{{ metal_core_grpc_ca_cert }}"

--- a/partition/roles/metal-core/templates/metal-core-env.j2
+++ b/partition/roles/metal-core/templates/metal-core-env.j2
@@ -4,6 +4,9 @@ METAL_CORE_LOOPBACK_IP: "{{ lo }}"
 METAL_CORE_ASN: "{{ asn }}"
 
 METAL_CORE_CIDR: "{{ metal_core_cidr }}"
+{% if metal_core_dhcp_servers is defined %}
+METAL_CORE_DHCP_SERVERS: "{{ metal_core_dhcp_servers | join(',') }}"
+{% endif %}
 METAL_CORE_PARTITION_ID: "{{ metal_partition_id }}"
 METAL_CORE_RACK_ID: "{{ metal_core_rack_id }}"
 METAL_CORE_BIND_ADDRESS: 0.0.0.0

--- a/partition/roles/metal-core/templates/metal-core-volumes.j2
+++ b/partition/roles/metal-core/templates/metal-core-volumes.j2
@@ -1,5 +1,10 @@
+{% if metal_stack_switch_os_is_sonic %}
+- /etc/sonic/:/etc/sonic
+- /var/run/redis/:/var/run/redis:ro
+{% else %}
 - /etc/network/:/etc/network
 - /etc/frr/:/etc/frr
+{% endif %}
 - /var/run/dbus:/var/run/dbus
 - /run/systemd/private:/run/systemd/private
 {% if metal_core_consider_hosts_file_resolution %}


### PR DESCRIPTION
References https://github.com/metal-stack/metal-core/pull/75. Changes here are backwards compatible and cannot break something.

The work on this PR started in https://github.com/metal-stack/metal-roles/pull/112.