### PR TITLE
Rename config save reload systemd service

### DIFF
--- a/partition/roles/sonic/files/frr-reload.service
+++ b/partition/roles/sonic/files/frr-reload.service
@@ -3,7 +3,6 @@ Description=Save and reload ConfigDB
 
 [Service]
 Type=oneshot
-ExecStartPre=/usr/local/bin/config save -y
 ExecStart=/usr/local/bin/frr-reload.py /etc/sonic/frr/frr.conf --reload --confdir /etc/sonic/frr --debug --rundir /etc/sonic/frr/
 StandardOutput=journal
 

--- a/partition/roles/sonic/tasks/main.yaml
+++ b/partition/roles/sonic/tasks/main.yaml
@@ -47,7 +47,7 @@
   with_items:
     - bgp-validation@.service
     - write-to-db@.service
-    - config-save-reload.service
+    - frr-reload.service
 
 - name: Render metal config for config_db.json
   template:


### PR DESCRIPTION
Also, removes `config save -y` from pre-start. It will be put in another place later.