### PR TITLE
DHCP static hosts include must be optional.

### DIFF
--- a/partition/roles/dhcp/templates/dhcpd.conf.j2
+++ b/partition/roles/dhcp/templates/dhcpd.conf.j2
@@ -23,4 +23,7 @@ subnet {{ subnet.network }} netmask {{ subnet.netmask }} {
 {% for option in dhcp_global_options %}
 option {{ option }};
 {% endfor %}
+
+{% if dhcp_static_hosts is defined %}
 include "/etc/dhcp/dhcpd.hosts";
+{% endif %}

--- a/partition/roles/dhcp/test/template_test.py
+++ b/partition/roles/dhcp/test/template_test.py
@@ -42,8 +42,6 @@ subnet 1.2.3.4 netmask 24 {
   option routers 2.2.2.2;
   option domain-name-servers 1.1.1.1, 8.8.8.8;
 }
-
-include "/etc/dhcp/dhcpd.hosts";
 """.strip(), res.strip())
 
     def test_dhcpd_hosts_config_template(self):


### PR DESCRIPTION
Otherwise the daemon will fail with "no such file or directory".