### PR TITLE
Fallback to metal control plane namespace when auditing variable is not set

### DIFF
--- a/control-plane/roles/metal/defaults/main/main.yaml
+++ b/control-plane/roles/metal/defaults/main/main.yaml
@@ -106,6 +106,6 @@ metal_api_headscale_internal_api_address: "headscale:50443"
 metal_auditing_enabled: false
 metal_auditing_index_prefix: "auditing"
 metal_auditing_index_interval: "@daily"
-metal_auditing_url: "http://auditing-meili-meilisearch.{{ auditing_meili_namespace }}.svc.cluster.local:7700"
+metal_auditing_url: "http://auditing-meili-meilisearch.{{ auditing_meili_namespace if auditing_meili_namespace is defined else metal_control_plane_namespace }}.svc.cluster.local:7700"
 metal_auditing_meili_secret_name: metal-auditing-master-key
 metal_auditing_meili_api_key: "{{ lookup('k8s', api_version='v1', namespace=auditing_meili_namespace, kind='Secret', resource_name='metal-auditing-master-key').get('data', {}).get('MEILI_MASTER_KEY') | b64decode if metal_auditing_enabled else '' }}"

--- a/control-plane/roles/metal/defaults/main/main.yaml
+++ b/control-plane/roles/metal/defaults/main/main.yaml
@@ -108,4 +108,4 @@ metal_auditing_index_prefix: "auditing"
 metal_auditing_index_interval: "@daily"
 metal_auditing_url: "http://auditing-meili-meilisearch.{{ auditing_meili_namespace if auditing_meili_namespace is defined else metal_control_plane_namespace }}.svc.cluster.local:7700"
 metal_auditing_meili_secret_name: metal-auditing-master-key
-metal_auditing_meili_api_key: "{{ lookup('k8s', api_version='v1', namespace=auditing_meili_namespace, kind='Secret', resource_name='metal-auditing-master-key').get('data', {}).get('MEILI_MASTER_KEY') | b64decode if metal_auditing_enabled else '' }}"
+metal_auditing_meili_api_key: "{{ lookup('k8s', api_version='v1', namespace=auditing_meili_namespace if auditing_meili_namespace is defined else metal_control_plane_namespace, kind='Secret', resource_name='metal-auditing-master-key').get('data', {}).get('MEILI_MASTER_KEY') | b64decode if metal_auditing_enabled else '' }}"


### PR DESCRIPTION
Otherwise, if not using the auditing-meili role in a deployment, the deployment fails with undefined variable.