### PR TITLE
Adaptions for g/g v1.52.

### DIFF
--- a/control-plane/roles/gardener/files/kube-apiserver/templates/deployment-kube-apiserver.yaml
+++ b/control-plane/roles/gardener/files/kube-apiserver/templates/deployment-kube-apiserver.yaml
@@ -189,8 +189,8 @@ spec:
           failureThreshold: 2
           httpGet:
             path: /healthz
-            port: 10252
-            scheme: HTTP
+            port: 10257
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 10
           successThreshold: 1

--- a/control-plane/roles/gardener/tasks/seed.yaml
+++ b/control-plane/roles/gardener/tasks/seed.yaml
@@ -69,9 +69,9 @@
 
 - name: Fetch current seed cidrs
   set_fact:
-    _gardener_current_soil_node_cidr: "{{ (lookup('k8s', kubeconfig=gardener_kube_apiserver_kubeconfig_path, api_version='core.gardener.cloud/v1alpha1', kind='Seed', resource_name=gardener_soil_name) | default({}, true)).get('spec', {}).get('networks', {}).get('nodes', none) }}"
-    _gardener_current_soil_pod_cidr: "{{ (lookup('k8s', kubeconfig=gardener_kube_apiserver_kubeconfig_path, api_version='core.gardener.cloud/v1alpha1', kind='Seed', resource_name=gardener_soil_name) | default({}, true)).get('spec', {}).get('networks', {}).get('pods', none) }}"
-    _gardener_current_soil_service_cidr: "{{ (lookup('k8s', kubeconfig=gardener_kube_apiserver_kubeconfig_path, api_version='core.gardener.cloud/v1alpha1', kind='Seed', resource_name=gardener_soil_name) | default({}, true)).get('spec', {}).get('networks', {}).get('services', none) }}"
+    _gardener_current_soil_node_cidr: "{{ (lookup('k8s', kubeconfig=gardener_kube_apiserver_kubeconfig_path, api_version='core.gardener.cloud/v1beta1', kind='Seed', resource_name=gardener_soil_name) | default({}, true)).get('spec', {}).get('networks', {}).get('nodes', none) }}"
+    _gardener_current_soil_pod_cidr: "{{ (lookup('k8s', kubeconfig=gardener_kube_apiserver_kubeconfig_path, api_version='core.gardener.cloud/v1beta1', kind='Seed', resource_name=gardener_soil_name) | default({}, true)).get('spec', {}).get('networks', {}).get('pods', none) }}"
+    _gardener_current_soil_service_cidr: "{{ (lookup('k8s', kubeconfig=gardener_kube_apiserver_kubeconfig_path, api_version='core.gardener.cloud/v1beta1', kind='Seed', resource_name=gardener_soil_name) | default({}, true)).get('spec', {}).get('networks', {}).get('services', none) }}"
 
 - name: Set cidrs for seed
   set_fact:
@@ -95,7 +95,7 @@
   retries: 60
   delay: 3
   until:
-    - "'conditions' in lookup('k8s', kubeconfig=gardener_kube_apiserver_kubeconfig_path, api_version='core.gardener.cloud/v1alpha1', kind='Seed', resource_name=gardener_soil_name).get('status', {})"
+    - "'conditions' in lookup('k8s', kubeconfig=gardener_kube_apiserver_kubeconfig_path, api_version='core.gardener.cloud/v1beta1', kind='Seed', resource_name=gardener_soil_name).get('status', {})"
     - lookup('k8s', kubeconfig=gardener_kube_apiserver_kubeconfig_path, api_version='core.gardener.cloud/v1beta1', kind='Seed', resource_name=gardener_soil_name).get('status', {}).conditions | length > 2
     - lookup('k8s', kubeconfig=gardener_kube_apiserver_kubeconfig_path, api_version='core.gardener.cloud/v1beta1', kind='Seed', resource_name=gardener_soil_name).get('status', {}).conditions[0].message == "Gardenlet is posting ready status."
     - lookup('k8s', kubeconfig=gardener_kube_apiserver_kubeconfig_path, api_version='core.gardener.cloud/v1beta1', kind='Seed', resource_name=gardener_soil_name).get('status', {}).conditions[2].message == "Seed cluster has been bootstrapped successfully."

--- a/control-plane/roles/gardener/templates/gardener-control-plane-values.j2
+++ b/control-plane/roles/gardener/templates/gardener-control-plane-values.j2
@@ -24,7 +24,6 @@ global:
     resources: {{ gardener_apiserver_resources | to_json }}
     featureGates:
       SeedChange: true
-      WorkerPoolKubernetesVersion: true
     image:
       repository: {{ gardener_apiserver_image_name }}
       tag: {{ gardener_apiserver_image_tag }}


### PR DESCRIPTION
- Supports virtual garden for k8s v1.22
- Completely moves to v1beta1 API
- Removes removed feature gate for worker pool k8s