### PR TITLE
fix: auditing-meili did not allow null values in persistence

### DIFF
--- a/control-plane/roles/auditing-meili/templates/values.yaml
+++ b/control-plane/roles/auditing-meili/templates/values.yaml
@@ -20,5 +20,5 @@ environment:
 auth:
   existingMasterKeySecret: metal-auditing-master-key
 
-persistence: {{ auditing_meili_persistence }}
-ingress: {{ auditing_meili_ingress }}
+persistence: {{ auditing_meili_persistence | to_json }}
+ingress: {{ auditing_meili_ingress | to_json }}


### PR DESCRIPTION
Required to set `storageClass: null` in mini-lab