### PR TITLE
fix: fsl type parsing

### DIFF
--- a/control-plane/roles/metal/templates/metal-values.j2
+++ b/control-plane/roles/metal/templates/metal-values.j2
@@ -146,7 +146,11 @@ metal_api:
   filesystemlayouts: |
 {% for entity in metal_api_filesystemlayouts %}
     ---
-    {{ entity | to_nice_yaml | indent(width=4, first=false) }}
+    {# 
+      Some FSL Types confuse different YAML-parsing implementations.
+      Hence we fall back to JSON to enforce quotes around literals like 8e00. 
+    #}
+    {{ entity | to_json | indent(width=4, first=false) }}
 {% endfor %}
   sizeimageconstraints: |
 {% for entity in metal_api_sizeimageconstraints %}


### PR DESCRIPTION
Different YAML parsing implementations handle literals like `8e00` differently. Enforcing quotes with jsonsolves this issue.