### PR TITLE
Changes for g/g v1.58 compatibility.

### DIFF
--- a/control-plane/roles/gardener/tasks/control-plane-networks/gcp.yaml
+++ b/control-plane/roles/gardener/tasks/control-plane-networks/gcp.yaml
@@ -34,7 +34,7 @@
 
 - name: Set pod cidr
   set_fact:
-    _gardener_soil_pod_cidr: "{{ lookup('k8s', kind='Node')[0].get('spec', {}).get('podCIDR') }}"
+    _gardener_soil_pod_cidr: "{{ (gcp_cluster.stdout | from_json)['ipAllocationPolicy']['clusterIpv4CidrBlock'] }}"
 
 - name: Set service cidr
   set_fact:


### PR DESCRIPTION
```ACTIONS_REQUIRED
Seeds were deployed with an incorrect `PodCIDR` in the past, which in Gardener 1.58 leads to a validation failure for `Seed` resources. Prior to updating to this version, the pod CIDR needs to be patched to the correct CIDR. This can be achieved through a modified gardener-apiserver image (`r.metal-stack.io/gardener/gardener-apiserver:remove-pod-cidr-validation`), built from [this fork branch](https://github.com/gardener/gardener/compare/v1.57.2...metal-stack:gardener:remove-pod-cidr-validation).
```