### PR TITLE
metal-bmc nsqd direct access

### DIFF
--- a/control-plane/README.md
+++ b/control-plane/README.md
@@ -10,8 +10,7 @@ Contains roles for deploying the metal-control-plane.
 
     | Port  | Protocol | Service Name  | Description                   |
     | ----- | -------- | ------------- | ----------------------------- |
-    | 4150  | TCP      | nsqd          | nsq Daemon (HTTPS)            |
-    | 4161  | TCP      | nsq-lookupd   | nsqlookup Damon (HTTP)        |
+    | 4150  | TCP      | nsqd          | nsq Daemon (TLS)              |
     | 5222  | TCP      | metal-console | Console forwarding (SSH)      |
     | 50051 | TCP      | metal-api     | metal-api gRPC API (protobuf) |
 

--- a/partition/roles/metal-bmc/README.md
+++ b/partition/roles/metal-bmc/README.md
@@ -8,23 +8,23 @@ This role uses variables from [partition-defaults](/partition). So, make sure yo
 
 You can look up all the default values of this role [here](defaults/main.yaml).
 
-| Name                         | Mandatory | Description                                                                                           |
-| ---------------------------- | --------- | ----------------------------------------------------------------------------------------------------- |
-| metal_bmc_image_name         | yes       | Image version of the metal-bmc                                                                        |
-| metal_bmc_image_tag          | yes       | Image tag of the metal-bmc                                                                            |
-| metal_bmc_superuser          | yes       | Name of the BMC superuser                                                                             |
-| metal_bmc_superuser_pwd      | yes       | Password of the BMC superuser                                                                         |
-| metal_bmc_nsq_lookupd_addr   | yes       | The address to the nsq-lookupd that metal-bmc uses for discovering the NSQ of the metal control plane |
-| metal_bmc_nsq_log_level      |           | The metal-core log level used on NSQ communication                                                    |
-| metal_bmc_nsq_tls_enabled    |           | Enables tls encryption on NSQ traffic                                                                 |
-| metal_bmc_nsq_cert_dir       |           | Defines the path of the NSQ certificates                                                              |
-| metal_bmc_nsqd_ca_cert       |           | The CA certificate that signed the NSQ client cert                                                    |
-| metal_bmc_nsqd_client_cert   |           | The NSQ client certificate                                                                            |
-| metal_bmc_console_port       |           | The port where to listen for incoming metal-console connections                                       |
-| metal_bmc_console_ca_cert    | yes       | The CA certificate for the metal-console port as a string                                             |
-| metal_bmc_console_cert       | yes       | The certificate for metal-console port as a string                                                    |
-| metal_bmc_console_key        | yes       | The key for the metal-console port  as a string                                                       |
-| metal_bmc_console_cert_owner |           | user of the created certificate files                                                                 |
-| metal_bmc_console_cert_group |           | group of the created certificate files                                                                |
-| metal_bmc_ignore_macs        |           | when fetching bmc reports from the dhcp lease file, the given macs are ignored                        |
-| metal_bmc_allowed_cidrs      |           | when fetching bmc reports from the dhcp lease file, ips in the given cidrs are ignored                |
+| Name                         | Mandatory | Description                                                                                    |
+| ---------------------------- | --------- | ---------------------------------------------------------------------------------------------- |
+| metal_bmc_image_name         | yes       | Image version of the metal-bmc                                                                 |
+| metal_bmc_image_tag          | yes       | Image tag of the metal-bmc                                                                     |
+| metal_bmc_superuser          | yes       | Name of the BMC superuser                                                                      |
+| metal_bmc_superuser_pwd      | yes       | Password of the BMC superuser                                                                  |
+| metal_bmc_nsqd_addr          | yes       | The address to the nsqd that metal-bmc uses for discovering the NSQ of the metal control plane |
+| metal_bmc_nsq_log_level      |           | The metal-core log level used on NSQ communication                                             |
+| metal_bmc_nsq_tls_enabled    |           | Enables tls encryption on NSQ traffic                                                          |
+| metal_bmc_nsq_cert_dir       |           | Defines the path of the NSQ certificates                                                       |
+| metal_bmc_nsqd_ca_cert       |           | The CA certificate that signed the NSQ client cert                                             |
+| metal_bmc_nsqd_client_cert   |           | The NSQ client certificate                                                                     |
+| metal_bmc_console_port       |           | The port where to listen for incoming metal-console connections                                |
+| metal_bmc_console_ca_cert    | yes       | The CA certificate for the metal-console port as a string                                      |
+| metal_bmc_console_cert       | yes       | The certificate for metal-console port as a string                                             |
+| metal_bmc_console_key        | yes       | The key for the metal-console port  as a string                                                |
+| metal_bmc_console_cert_owner |           | user of the created certificate files                                                          |
+| metal_bmc_console_cert_group |           | group of the created certificate files                                                         |
+| metal_bmc_ignore_macs        |           | when fetching bmc reports from the dhcp lease file, the given macs are ignored                 |
+| metal_bmc_allowed_cidrs      |           | when fetching bmc reports from the dhcp lease file, ips in the given cidrs are ignored         |

--- a/partition/roles/metal-bmc/README.md
+++ b/partition/roles/metal-bmc/README.md
@@ -8,23 +8,24 @@ This role uses variables from [partition-defaults](/partition). So, make sure yo
 
 You can look up all the default values of this role [here](defaults/main.yaml).
 
-| Name                         | Mandatory | Description                                                                                    |
-| ---------------------------- | --------- | ---------------------------------------------------------------------------------------------- |
-| metal_bmc_image_name         | yes       | Image version of the metal-bmc                                                                 |
-| metal_bmc_image_tag          | yes       | Image tag of the metal-bmc                                                                     |
-| metal_bmc_superuser          | yes       | Name of the BMC superuser                                                                      |
-| metal_bmc_superuser_pwd      | yes       | Password of the BMC superuser                                                                  |
-| metal_bmc_nsqd_addr          | yes       | The address to the nsqd that metal-bmc uses for discovering the NSQ of the metal control plane |
-| metal_bmc_nsq_log_level      |           | The metal-core log level used on NSQ communication                                             |
-| metal_bmc_nsq_tls_enabled    |           | Enables tls encryption on NSQ traffic                                                          |
-| metal_bmc_nsq_cert_dir       |           | Defines the path of the NSQ certificates                                                       |
-| metal_bmc_nsqd_ca_cert       |           | The CA certificate that signed the NSQ client cert                                             |
-| metal_bmc_nsqd_client_cert   |           | The NSQ client certificate                                                                     |
-| metal_bmc_console_port       |           | The port where to listen for incoming metal-console connections                                |
-| metal_bmc_console_ca_cert    | yes       | The CA certificate for the metal-console port as a string                                      |
-| metal_bmc_console_cert       | yes       | The certificate for metal-console port as a string                                             |
-| metal_bmc_console_key        | yes       | The key for the metal-console port  as a string                                                |
-| metal_bmc_console_cert_owner |           | user of the created certificate files                                                          |
-| metal_bmc_console_cert_group |           | group of the created certificate files                                                         |
-| metal_bmc_ignore_macs        |           | when fetching bmc reports from the dhcp lease file, the given macs are ignored                 |
-| metal_bmc_allowed_cidrs      |           | when fetching bmc reports from the dhcp lease file, ips in the given cidrs are ignored         |
+| Name                           | Mandatory | Description                                                                                    |
+| ------------------------------ | --------- | ---------------------------------------------------------------------------------------------- |
+| metal_bmc_image_name           | yes       | Image version of the metal-bmc                                                                 |
+| metal_bmc_image_tag            | yes       | Image tag of the metal-bmc                                                                     |
+| metal_bmc_superuser            | yes       | Name of the BMC superuser                                                                      |
+| metal_bmc_superuser_pwd        | yes       | Password of the BMC superuser                                                                  |
+| metal_bmc_nsqd_addr            | yes       | The address to the nsqd that metal-bmc uses for discovering the NSQ of the metal control plane |
+| metal_bmc_nsq_log_level        |           | The metal-core log level used on NSQ communication                                             |
+| metal_bmc_nsq_tls_enabled      |           | Enables tls encryption on NSQ traffic                                                          |
+| metal_bmc_nsq_cert_dir         |           | Defines the path of the NSQ certificates                                                       |
+| metal_bmc_nsqd_ca_cert         |           | The CA certificate that signed the NSQ client cert                                             |
+| metal_bmc_nsqd_client_cert     |           | The NSQ client certificate                                                                     |
+| metal_bmc_nsqd_client_cert_key |           | The NSQ client certificate key                                                                 |
+| metal_bmc_console_port         |           | The port where to listen for incoming metal-console connections                                |
+| metal_bmc_console_ca_cert      | yes       | The CA certificate for the metal-console port as a string                                      |
+| metal_bmc_console_cert         | yes       | The certificate for metal-console port as a string                                             |
+| metal_bmc_console_key          | yes       | The key for the metal-console port  as a string                                                |
+| metal_bmc_console_cert_owner   |           | user of the created certificate files                                                          |
+| metal_bmc_console_cert_group   |           | group of the created certificate files                                                         |
+| metal_bmc_ignore_macs          |           | when fetching bmc reports from the dhcp lease file, the given macs are ignored                 |
+| metal_bmc_allowed_cidrs        |           | when fetching bmc reports from the dhcp lease file, ips in the given cidrs are ignored         |

--- a/partition/roles/metal-bmc/defaults/main/main.yaml
+++ b/partition/roles/metal-bmc/defaults/main/main.yaml
@@ -11,6 +11,7 @@ metal_bmc_nsq_tls_enabled: true
 metal_bmc_nsq_cert_dir: /certs/nsq
 metal_bmc_nsqd_ca_cert:
 metal_bmc_nsqd_client_cert:
+metal_bmc_nsqd_client_cert_key:
 
 metal_bmc_console_port: 3333
 metal_bmc_console_cert_owner: root

--- a/partition/roles/metal-bmc/tasks/main.yaml
+++ b/partition/roles/metal-bmc/tasks/main.yaml
@@ -34,6 +34,8 @@
       content: "{{ metal_bmc_nsqd_ca_cert }}"
     - filename: client.pem
       content: "{{ metal_bmc_nsqd_client_cert }}"
+    - filename: client-key.pem
+      content: "{{ metal_bmc_nsqd_client_cert_key }}"
   loop_control:
     label: "{{ item.filename }}"
   when: metal_bmc_nsq_tls_enabled
@@ -95,6 +97,7 @@
       METAL_BMC_MQ_LOGLEVEL: "{{ metal_bmc_nsq_log_level }}"
       METAL_BMC_MQ_CA_CERT_FILE: "{{metal_bmc_nsq_cert_dir }}/ca.pem"
       METAL_BMC_MQ_CLIENT_CERT_FILE: "{{ metal_bmc_nsq_cert_dir }}/client.pem"
+      METAL_BMC_MQ_CLIENT_CERT_KEY_FILE: "{{ metal_bmc_nsq_cert_dir }}/client-key.pem"
       METAL_BMC_MACHINE_TOPIC: "{{ metal_partition_id }}-machine"
       METAL_BMC_CONSOLE_PORT: "{{ metal_bmc_console_port }}"
       METAL_BMC_CONSOLE_CA_CERT_FILE: "{{metal_bmc_console_cert_dir }}/ca.pem"

--- a/partition/roles/metal-bmc/tasks/main.yaml
+++ b/partition/roles/metal-bmc/tasks/main.yaml
@@ -7,6 +7,7 @@
     fail_msg: "not all mandatory variables given, check role documentation"
     quiet: yes
     that:
+      - metal_bmc_nsqd_addr is defined
       - metal_bmc_image_tag is defined
       - metal_bmc_image_name is defined
       - metal_bmc_bmc_superuser is defined
@@ -93,7 +94,7 @@
       METAL_BMC_ALLOWED_CIDRS: "{{ metal_bmc_allowed_cidrs | join(',') }}"
       METAL_BMC_IPMI_USER: "{{ metal_bmc_bmc_superuser }}"
       METAL_BMC_IPMI_PASSWORD: "{{ metal_bmc_bmc_superuser_pwd }}"
-      METAL_BMC_MQ_ADDRESS: "{{ metal_bmc_nsq_lookupd_addr }}"
+      METAL_BMC_MQ_ADDRESS: "{{ metal_bmc_nsqd_addr }}"
       METAL_BMC_MQ_LOGLEVEL: "{{ metal_bmc_nsq_log_level }}"
       METAL_BMC_MQ_CA_CERT_FILE: "{{metal_bmc_nsq_cert_dir }}/ca.pem"
       METAL_BMC_MQ_CLIENT_CERT_FILE: "{{ metal_bmc_nsq_cert_dir }}/client.pem"

--- a/partition/roles/metal-bmc/tasks/main.yaml
+++ b/partition/roles/metal-bmc/tasks/main.yaml
@@ -14,6 +14,7 @@
       - metal_bmc_bmc_superuser_pwd is defined
       - not metal_bmc_nsq_tls_enabled or (metal_bmc_nsq_tls_enabled and metal_bmc_nsqd_ca_cert is not none)
       - not metal_bmc_nsq_tls_enabled or (metal_bmc_nsq_tls_enabled and metal_bmc_nsqd_client_cert is not none)
+      - not metal_bmc_nsq_tls_enabled or (metal_bmc_nsq_tls_enabled and metal_bmc_nsqd_client_cert_key is not none)
       - metal_bmc_console_ca_cert is not none
       - metal_bmc_console_cert is not none
       - metal_bmc_console_key is not none


### PR DESCRIPTION
References https://github.com/metal-stack/metal-bmc/pull/39

```ACTIONS_REQUIRED
The metal-bmc now directly communicates with NSQd. The deployment has adjusted to point the metal-bmc to the NSQd instead of the lookupd.
```