### PR TITLE
Render SONiC `config_db.json` directly without using `sonic-cfggen`

### DIFF
--- a/partition/roles/sonic/README.md
+++ b/partition/roles/sonic/README.md
@@ -17,7 +17,7 @@ It depends on the `switch_facts` module from `ansible-common`, so make sure modu
 | sonic_mgmtif_gateway                                       |           | If using a fixed management IP, the default gateway for the management interface.                                    |
 | sonic_ip_masquerade                                        |           | Enable ip masquerading on eth0.                                                                                      |
 | sonic_breakouts                                            |           | The breakout configuration for ports, e.g. `dict('Ethernet0'='4x25G')`                                               |
-| sonic_config_action                                        |           | Either `load` or `reload`. In the latter case all services will be restarted.                                        |
+| sonic_config_action                                        |           | Either `load` or `reload`. In the latter case all services will be restarted. If not given, defaults to `load`       |
 | sonic_ports                                                |           | Configuration for ports (mtu, fec, have highest precedence). These ports will be up by default.                      |
 | sonic_ports.name                                           |           | The port name.                                                                                                       |
 | sonic_ports.speed                                          |           | Speed of the port.                                                                                                   |

--- a/partition/roles/sonic/README.md
+++ b/partition/roles/sonic/README.md
@@ -17,8 +17,8 @@ It depends on the `switch_facts` module from `ansible-common`, so make sure modu
 | sonic_mgmtif_gateway                                       |           | If using a fixed management IP, the default gateway for the management interface.                                    |
 | sonic_ip_masquerade                                        |           | Enable ip masquerading on eth0.                                                                                      |
 | sonic_breakouts                                            |           | The breakout configuration for ports, e.g. `dict('Ethernet0'='4x25G')`                                               |
-| sonic_ports                                                |           | Special configuration for ports (mtu, fec, have highest precedence)                                                  |
-| sonic_ports.name                                           |           | The port name.                                                                                                       |
+| sonic_config_action                                        |           | Either `load` or `reload`. In the latter case all services will be restarted.                                        |
+| sonic_ports                                                |           | Configuration for ports (mtu, fec, have highest precedence). These ports will be up by default.                      |
 | sonic_ports.speed                                          |           | Speed of the port.                                                                                                   |
 | sonic_ports.mtu                                            |           | MTU of the port.                                                                                                     |
 | sonic_ports.fec                                            |           | FEC used for the port.                                                                                               |
@@ -42,7 +42,7 @@ It depends on the `switch_facts` module from `ansible-common`, so make sure modu
 | sonic_vlans.ip                                             |           | The IP of the SVI of this VLAN.                                                                                      |
 | sonic_vlans.dhcp_servers                                   |           | DHCP servers to relay to.                                                                                            |
 | sonic_vlans.untagged_ports                                 |           | Array of untagged ports to bind to this VLAN.                                                                        |
-| sonic_vlans.tagged_ports                                   |           | Array of tagged ports to bind to this VLAN.                                                                        |
+| sonic_vlans.tagged_ports                                   |           | Array of tagged ports to bind to this VLAN.                                                                          |
 | sonic_vlans.vrf                                            |           | The VRF to bind the VLANs SVI to.                                                                                    |
 | sonic_vteps                                                |           | VTEPs to configure. If defined FRR will automatically advertise all VNIs.                                            |
 | sonic_vteps.comment                                        |           | Description for the VTEP.                                                                                            |

--- a/partition/roles/sonic/README.md
+++ b/partition/roles/sonic/README.md
@@ -19,6 +19,7 @@ It depends on the `switch_facts` module from `ansible-common`, so make sure modu
 | sonic_breakouts                                            |           | The breakout configuration for ports, e.g. `dict('Ethernet0'='4x25G')`                                               |
 | sonic_config_action                                        |           | Either `load` or `reload`. In the latter case all services will be restarted.                                        |
 | sonic_ports                                                |           | Configuration for ports (mtu, fec, have highest precedence). These ports will be up by default.                      |
+| sonic_ports.name                                           |           | The port name.                                                                                                       |
 | sonic_ports.speed                                          |           | Speed of the port.                                                                                                   |
 | sonic_ports.mtu                                            |           | MTU of the port.                                                                                                     |
 | sonic_ports.fec                                            |           | FEC used for the port.                                                                                               |

--- a/partition/roles/sonic/defaults/main.yaml
+++ b/partition/roles/sonic/defaults/main.yaml
@@ -9,6 +9,7 @@ sonic_config_action: reload
 ## Physical settings
 sonic_breakouts: {}
 sonic_ports: []
+sonic_ports_dict: {}
 sonic_ports_default_fec: none
 
 ## BGP related settings

--- a/partition/roles/sonic/defaults/main.yaml
+++ b/partition/roles/sonic/defaults/main.yaml
@@ -9,6 +9,7 @@ sonic_config_action: reload
 ## Physical settings
 sonic_breakouts: {}
 sonic_ports: []
+sonic_ports_default_fec: none
 
 ## BGP related settings
 sonic_loopback_address:

--- a/partition/roles/sonic/defaults/main.yaml
+++ b/partition/roles/sonic/defaults/main.yaml
@@ -4,6 +4,7 @@ sonic_ntpservers: []
 sonic_nameservers: []
 sonic_ip_masquerade: false
 sonic_timezone: Europe/Berlin
+sonic_config_action: reload
 
 ## Physical settings
 sonic_breakouts: {}

--- a/partition/roles/sonic/defaults/main.yaml
+++ b/partition/roles/sonic/defaults/main.yaml
@@ -4,7 +4,7 @@ sonic_ntpservers: []
 sonic_nameservers: []
 sonic_ip_masquerade: false
 sonic_timezone: Europe/Berlin
-sonic_config_action: reload
+sonic_config_action: load
 
 ## Physical settings
 sonic_breakouts: {}

--- a/partition/roles/sonic/defaults/main.yaml
+++ b/partition/roles/sonic/defaults/main.yaml
@@ -9,11 +9,6 @@ sonic_config_action: reload
 ## Physical settings
 sonic_breakouts: {}
 sonic_ports: []
-#- name: Ethernet50
-#  speed: 10000
-sonic_ports_default_speed: 10000
-sonic_ports_default_mtu: 9216
-sonic_ports_default_fec: none 
 
 ## BGP related settings
 sonic_loopback_address:

--- a/partition/roles/sonic/handlers/main.yaml
+++ b/partition/roles/sonic/handlers/main.yaml
@@ -3,18 +3,6 @@
   systemd:
     daemon_reload: yes
 
-- name: write metal conf to db
-  ansible.builtin.command: sonic-cfggen --yaml /etc/sonic/metal.yaml --write-to-db
-  notify: config save
-
-- name: config save
-  ansible.builtin.command: config save -y
-
-- name: config save and reload
-  systemd:
-    name: config-save-reload
-    state: started
-
 - name: restart bgp
   systemd:
     name: bgp
@@ -25,8 +13,11 @@
     name: caclmgrd
     state: restarted
 
+- name: config load
+  ansible.builtin.command: config load --yes
+
 - name: config reload
-  ansible.builtin.command: config reload -y
+  ansible.builtin.command: config reload --yes
   async: 120
   poll: 0
   notify: wait for new connection

--- a/partition/roles/sonic/handlers/main.yaml
+++ b/partition/roles/sonic/handlers/main.yaml
@@ -3,11 +3,6 @@
   systemd:
     daemon_reload: yes
 
-- name: restart bgp
-  systemd:
-    name: bgp
-    state: restarted
-
 - name: restart caclmgrd
   systemd:
     name: caclmgrd
@@ -28,3 +23,8 @@
     sleep: 5
     delay: 30
     timeout: 300
+
+- name: restart bgp
+  systemd:
+    name: bgp
+    state: restarted

--- a/partition/roles/sonic/tasks/main.yaml
+++ b/partition/roles/sonic/tasks/main.yaml
@@ -71,7 +71,7 @@
     sonic_running_cfg_platform: "{{ sonic_running_cfg | community.general.json_query('DEVICE_METADATA.localhost.platform') }}"
     sonic_running_cfg_ports: "{{ sonic_running_cfg | community.general.json_query('PORT')  }}"
 
-- name: Fail if running configuration doesn't contain required informations
+- name: Fail if running configuration doesn't contain required information
   ansible.builtin.assert:
     that:
       - sonic_running_cfg_breakouts is defined and sonic_running_cfg_breakouts | length > 0

--- a/partition/roles/sonic/tasks/main.yaml
+++ b/partition/roles/sonic/tasks/main.yaml
@@ -20,9 +20,8 @@
     fail_msg: "default port configuration is necessary on non-empty sonic_ports"
     quiet: yes
     that:
-      - sonic_ports_default_speed is defined
-      - sonic_ports_default_mtu is defined
-      - sonic_ports_default_fec is defined
+      - sonic_ports_default_speed
+      - sonic_ports_default_mtu
   when: sonic_ports
 
 - name: Populate sonic_ports_dict

--- a/partition/roles/sonic/tasks/main.yaml
+++ b/partition/roles/sonic/tasks/main.yaml
@@ -55,13 +55,17 @@
   when: sonic_breakouts is defined
 
 - name: Delete deprecated metal.yaml
-  file:
+  ansible.builtin.file:
     path: "/etc/sonic/metal.yaml"
     state: absent
 
 - name: Get running configuration
   ansible.builtin.command: show runningconfiguration all
-  register: sonic_running_cfg
+  register: sonic_running_cfg_result
+
+- name: Parse running configuration
+  ansible.builtin.set_fact:
+    sonic_running_cfg: "{{ sonic_running_cfg_result.stdout | from_json }}"
 
 - name: Extract running configuration for breakouts and ports
   ansible.builtin.set_fact:
@@ -74,17 +78,12 @@
 - name: Fail if running configuration doesn't contain required information
   ansible.builtin.assert:
     that:
-      - sonic_running_cfg_breakouts is defined and sonic_running_cfg_breakouts | length > 0
-      - sonic_running_cfg_hwsku is defined and sonic_running_cfg_hwsku | length > 0
-      - sonic_running_cfg_mac is defined and sonic_running_cfg_mac | length > 0
-      - sonic_running_cfg_platform is defined and sonic_running_cfg_platform | length > 0
-      - sonic_running_cfg_ports is defined and sonic_running_cfg_ports | length > 0
+      - sonic_running_cfg_breakouts
+      - sonic_running_cfg_hwsku
+      - sonic_running_cfg_mac
+      - sonic_running_cfg_platform
+      - sonic_running_cfg_ports
     fail_msg: The running configuration is incomplete because it does not contain 'BREAKOUT_CFG', 'PORT', or complete 'DEVICE_METADATA'.
-
-- name: Fail if running configuration doesn't contain 'PORT'
-  ansible.builtin.fail:
-    msg: The running configuration doesn't contain 'PORT' {{ sonic_running_cfg }}
-  when: "sonic_running_cfg_ports | length == 0"
 
 - name: Render config_db
   set_fact:

--- a/partition/roles/sonic/tasks/main.yaml
+++ b/partition/roles/sonic/tasks/main.yaml
@@ -54,6 +54,11 @@
   with_dict: "{{ sonic_breakouts }}"
   when: sonic_breakouts is defined
 
+- name: Delete deprecated metal.yaml
+  file:
+    path: "/etc/sonic/metal.yaml"
+    state: absent
+
 - name: Get running configuration
   ansible.builtin.command: show runningconfiguration all
   register: sonic_running_cfg

--- a/partition/roles/sonic/tasks/main.yaml
+++ b/partition/roles/sonic/tasks/main.yaml
@@ -14,6 +14,17 @@
       - sonic_ntpservers is defined
       - sonic_nameservers is defined
       - metal_stack_switch_os_is_sonic
+
+- name: Check mandatory variables on non-empty sonic_ports are set
+  assert:
+    fail_msg: "default port configuration is necessary on non-empty sonic_ports"
+    quiet: yes
+    that:
+      - sonic_ports_default_speed is defined
+      - sonic_ports_default_mtu is defined
+      - sonic_ports_default_fec is defined
+  when: sonic_ports
+
 - name: Populate sonic_ports_dict
   set_fact:
     sonic_ports_dict: "{{ sonic_ports_dict|default({}) | combine( {item.name: item} ) }}"

--- a/partition/roles/sonic/tasks/main.yaml
+++ b/partition/roles/sonic/tasks/main.yaml
@@ -14,6 +14,10 @@
       - sonic_ntpservers is defined
       - sonic_nameservers is defined
       - metal_stack_switch_os_is_sonic
+- name: Populate sonic_ports_dict
+  set_fact:
+    sonic_ports_dict: "{{ sonic_ports_dict|default({}) | combine( {item.name: item} ) }}"
+  loop: "{{ sonic_ports }}"
 
 - name: render resolv.conf
   template:

--- a/partition/roles/sonic/tasks/main.yaml
+++ b/partition/roles/sonic/tasks/main.yaml
@@ -76,6 +76,7 @@
 - name: Get running configuration
   ansible.builtin.command: show runningconfiguration all
   register: sonic_running_cfg_result
+  changed_when: false
 
 - name: Parse running configuration
   ansible.builtin.set_fact:

--- a/partition/roles/sonic/tasks/main.yaml
+++ b/partition/roles/sonic/tasks/main.yaml
@@ -10,6 +10,7 @@
       - sonic_mgmt_vrf is defined
       - sonic_loopback_address is defined
       - sonic_asn is defined
+      - sonic_config_action in ['load', 'reload']
       - sonic_ntpservers is defined
       - sonic_nameservers is defined
       - metal_stack_switch_os_is_sonic
@@ -53,13 +54,42 @@
   with_dict: "{{ sonic_breakouts }}"
   when: sonic_breakouts is defined
 
-- name: Render metal config for config_db.json
-  template:
-    src: metal.yaml.j2
-    dest: /etc/sonic/metal.yaml
-  notify:
-  - write metal conf to db
-  - config reload
+- name: Get running configuration
+  ansible.builtin.command: show runningconfiguration all
+  register: sonic_running_cfg
+
+- name: Extract running configuration for breakouts and ports
+  ansible.builtin.set_fact:
+    sonic_running_cfg_breakouts: "{{ sonic_running_cfg | community.general.json_query('BREAKOUT_CFG') }}"
+    sonic_running_cfg_hwsku: "{{ sonic_running_cfg | community.general.json_query('DEVICE_METADATA.localhost.hwsku') }}"
+    sonic_running_cfg_mac: "{{ sonic_running_cfg | community.general.json_query('DEVICE_METADATA.localhost.mac') }}"
+    sonic_running_cfg_platform: "{{ sonic_running_cfg | community.general.json_query('DEVICE_METADATA.localhost.platform') }}"
+    sonic_running_cfg_ports: "{{ sonic_running_cfg | community.general.json_query('PORT')  }}"
+
+- name: Fail if running configuration doesn't contain required informations
+  ansible.builtin.assert:
+    that:
+      - sonic_running_cfg_breakouts is defined and sonic_running_cfg_breakouts | length > 0
+      - sonic_running_cfg_hwsku is defined and sonic_running_cfg_hwsku | length > 0
+      - sonic_running_cfg_mac is defined and sonic_running_cfg_mac | length > 0
+      - sonic_running_cfg_platform is defined and sonic_running_cfg_platform | length > 0
+      - sonic_running_cfg_ports is defined and sonic_running_cfg_ports | length > 0
+    fail_msg: The running configuration is incomplete because it does not contain 'BREAKOUT_CFG', 'PORT', or complete 'DEVICE_METADATA'.
+
+- name: Fail if running configuration doesn't contain 'PORT'
+  ansible.builtin.fail:
+    msg: The running configuration doesn't contain 'PORT' {{ sonic_running_cfg }}
+  when: "sonic_running_cfg_ports | length == 0"
+
+- name: Render config_db
+  set_fact:
+    config_db: "{{ lookup('template', 'metal.yaml.j2') }}"
+
+- name: Save config_db as JSON file
+  copy:
+    content: "{{ config_db | from_yaml | to_nice_json }}"
+    dest: /etc/sonic/config_db.json
+  notify: "config {{ sonic_config_action }}"
 
 - name: Set NTP timezone
   timezone:

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -75,13 +75,13 @@ BREAKOUT_CFG:
   {% endfor %}
 
 PORT:
-  {% for name, cfg in sonic_running_cfg_ports.items() %}
+  {% for name, running_cfg in sonic_running_cfg_ports.items() %}
   {{ name }}:
-    alias: {{ cfg.alias }}
+    alias: {{ running_cfg.alias }}
     autoneg: "off"
-    index: "{{ cfg.index }}"
-    lanes: "{{ cfg.lanes }}"
-    parent_port: {{ cfg.parent_port }}
+    index: "{{ running_cfg.index }}"
+    lanes: "{{ running_cfg.lanes }}"
+    parent_port: {{ running_cfg.parent_port }}
     {% if sonic_ports_dict[name] is defined %}
     {% set port = sonic_ports_dict[name] %}
     admin_status: up
@@ -89,7 +89,7 @@ PORT:
     mtu: "{{ port.mtu|default(sonic_ports_default_mtu) }}"
     fec: "{{ port.fec|default(sonic_ports_default_fec)|string|lower }}"
     {% else %}
-    speed: "{{ cfg.speed }}"
+    speed: "{{ running_cfg.speed }}"
     {% endif %}
   {% endfor %}
 {% if sonic_vlans is defined and sonic_vlans|length > 0 %}

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -85,13 +85,11 @@ PORT:
     {% if sonic_ports_dict[name] is defined %}
     {% set port = sonic_ports_dict[name] %}
     admin_status: up
-    speed: "{{ port.speed|default(cfg.speed) }}"
+    speed: "{{ port.speed|default(sonic_ports_default_speed) }}"
     mtu: "{{ port.mtu|default(sonic_ports_default_mtu) }}"
     fec: "{{ port.fec|default(sonic_ports_default_fec)|string|lower }}"
     {% else %}
     speed: "{{ cfg.speed }}"
-    mtu: "{{ sonic_ports_default_mtu }}"
-    fec: "{{ sonic_ports_default_fec|string|lower }}"
     {% endif %}
   {% endfor %}
 {% if sonic_vlans is defined and sonic_vlans|length > 0 %}

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -50,20 +50,20 @@ MGMT_VRF_CONFIG:
 {% if sonic_ports|length > 0 %}
 
 INTERFACE:
-  {% for name, cfg in sonic_ports.items() %}
-  {% if name in sonic_bgp_ports|default([]) or cfg.vrf is defined %}
-  {{ name }}:
-    {% if name in sonic_bgp_ports|default([]) %}
+  {% for port in sonic_ports %}
+  {% if port.name in sonic_bgp_ports|default([]) or port.vrf is defined %}
+  {{ port.name }}:
+    {% if port.name in sonic_bgp_ports|default([]) %}
     ipv6_use_link_local_only: enable
     {% endif %}
-    {% if cfg.vrf is defined %}
-    vrf_name: "{{ cfg.vrf }}"
+    {% if port.vrf is defined %}
+    vrf_name: "{{ port.vrf }}"
     {% endif %}
   {% elif port.ips is defined %}
   {{ port.name }}: {}
   {% endif %}
-  {% for ip in cfg.ips|default([]) %}
-  {{ name }}|{{ ip }}: {}
+  {% for ip in port.ips|default([]) %}
+  {{ port.name }}|{{ ip }}: {}
   {% endfor %}
   {% endfor %}
 {% endif %}

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -82,11 +82,12 @@ PORT:
     index: "{{ cfg.index }}"
     lanes: "{{ cfg.lanes }}"
     parent_port: {{ cfg.parent_port }}
-    {% if sonic_ports[name] is defined %}
+    {% if sonic_ports_dict[name] is defined %}
+    {% set port = sonic_ports_dict[name] %}
     admin_status: up
-    speed: "{{ sonic_ports[name].speed|default(cfg.speed) }}"
-    mtu: "{{ sonic_ports[name].mtu|default(sonic_ports_default_mtu) }}"
-    fec: "{{ sonic_ports[name].fec|default(sonic_ports_default_fec)|string|lower }}"
+    speed: "{{ port.speed|default(cfg.speed) }}"
+    mtu: "{{ port.mtu|default(sonic_ports_default_mtu) }}"
+    fec: "{{ port.fec|default(sonic_ports_default_fec)|string|lower }}"
     {% else %}
     speed: "{{ cfg.speed }}"
     mtu: "{{ sonic_ports_default_mtu }}"

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -78,7 +78,7 @@ PORT:
   {% for name, running_cfg in sonic_running_cfg_ports.items() %}
   {{ name }}:
     alias: {{ running_cfg.alias }}
-    autoneg: "off"
+    autoneg: "{{ running_cfg.autoneg|default("off")|string|lower }}"
     index: "{{ running_cfg.index }}"
     lanes: "{{ running_cfg.lanes }}"
     parent_port: {{ running_cfg.parent_port }}

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -37,6 +37,12 @@ MGMT_INTERFACE:
   eth0|{{ sonic_mgmtif_ip }}: {}
 {% endif %}
 
+MGMT_PORT:
+  eth0:
+    alias: "eth0"
+    admin_status: "up"
+    description: "Management Port"
+
 {% endif %}
 MGMT_VRF_CONFIG:
   vrf_global:

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -4,6 +4,9 @@ DEVICE_METADATA:
   localhost:
     docker_routing_config_mode: split
     hostname: "{{ inventory_hostname }}"
+    hwsku: "{{ sonic_running_cfg_hwsku }}"
+    mac: "{{ sonic_running_cfg_mac }}"
+    platform: "{{ sonic_running_cfg_platform }}"
     type: "LeafRouter"
     frr_mgmt_framework_config: "true"
 
@@ -41,34 +44,49 @@ MGMT_VRF_CONFIG:
 {% if sonic_ports|length > 0 %}
 
 INTERFACE:
-  {% for port in sonic_ports %}
-  {% if port.name in sonic_bgp_ports|default([]) or port.vrf is defined %}
-  {{ port.name }}:
-    {% if port.name in sonic_bgp_ports|default([]) %}
+  {% for name, cfg in sonic_ports.items() %}
+  {% if name in sonic_bgp_ports|default([]) or cfg.vrf is defined %}
+  {{ name }}:
+    {% if name in sonic_bgp_ports|default([]) %}
     ipv6_use_link_local_only: enable
     {% endif %}
-    {% if port.vrf is defined %}
-    vrf_name: "{{ port.vrf }}"
+    {% if cfg.vrf is defined %}
+    vrf_name: "{{ cfg.vrf }}"
     {% endif %}
   {% elif port.ips is defined %}
   {{ port.name }}: {}
   {% endif %}
-  {% for ip in port.ips|default([]) %}
-  {{ port.name }}|{{ ip }}: {}
+  {% for ip in cfg.ips|default([]) %}
+  {{ name }}|{{ ip }}: {}
   {% endfor %}
   {% endfor %}
 {% endif %}
-{% if sonic_ports|length > 0 %}
+
+BREAKOUT_CFG:
+  {% for name, cfg in sonic_running_cfg_breakouts.items() %}
+  {{ name }}:
+    brkout_mode: "{{ cfg.brkout_mode }}"
+  {% endfor %}
 
 PORT:
-  {% for port in sonic_ports %}
-  {{ port.name }}:
+  {% for name, cfg in sonic_running_cfg_ports.items() %}
+  {{ name }}:
+    alias: {{ cfg.alias }}
+    autoneg: "off"
+    index: "{{ cfg.index }}"
+    lanes: "{{ cfg.lanes }}"
+    parent_port: {{ cfg.parent_port }}
+    {% if sonic_ports[name] is defined %}
     admin_status: up
-    speed: "{{ port.speed|default(sonic_ports_default_speed) }}"
-    mtu: "{{ port.mtu|default(sonic_ports_default_mtu) }}"
-    fec: "{{ port.fec|default(sonic_ports_default_fec)|string|lower }}"
+    speed: "{{ sonic_ports[name].speed|default(cfg.speed) }}"
+    mtu: "{{ sonic_ports[name].mtu|default(sonic_ports_default_mtu) }}"
+    fec: "{{ sonic_ports[name].fec|default(sonic_ports_default_fec)|string|lower }}"
+    {% else %}
+    speed: "{{ cfg.speed }}"
+    mtu: "{{ sonic_ports_default_mtu }}"
+    fec: "{{ sonic_ports_default_fec|string|lower }}"
+    {% endif %}
   {% endfor %}
-{% endif %}
 {% if sonic_vlans is defined and sonic_vlans|length > 0 %}
 
 VLAN:

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -37,33 +37,33 @@ MGMT_INTERFACE:
   eth0|{{ sonic_mgmtif_ip }}: {}
 {% endif %}
 
+{% endif %}
 MGMT_PORT:
   eth0:
     alias: "eth0"
     admin_status: "up"
     description: "Management Port"
 
-{% endif %}
 MGMT_VRF_CONFIG:
   vrf_global:
     mgmtVrfEnabled: "{{ sonic_mgmt_vrf | lower }}"
-{% if sonic_ports|length > 0 %}
+{% if sonic_ports_dict|length > 0 %}
 
 INTERFACE:
-  {% for port in sonic_ports %}
-  {% if port.name in sonic_bgp_ports|default([]) or port.vrf is defined %}
-  {{ port.name }}:
-    {% if port.name in sonic_bgp_ports|default([]) %}
+  {% for name, port in sonic_ports_dict.items() %}
+  {% if name in sonic_bgp_ports|default([]) or port.vrf is defined %}
+  {{ name }}:
+    {% if name in sonic_bgp_ports|default([]) %}
     ipv6_use_link_local_only: enable
     {% endif %}
     {% if port.vrf is defined %}
     vrf_name: "{{ port.vrf }}"
     {% endif %}
   {% elif port.ips is defined %}
-  {{ port.name }}: {}
+  {{ name }}: {}
   {% endif %}
   {% for ip in port.ips|default([]) %}
-  {{ port.name }}|{{ ip }}: {}
+  {{ name }}|{{ ip }}: {}
   {% endfor %}
   {% endfor %}
 {% endif %}

--- a/partition/roles/sonic/test/data/exit/input.yaml
+++ b/partition/roles/sonic/test/data/exit/input.yaml
@@ -6,22 +6,16 @@ sonic_loopback_address: 10.0.0.1
 sonic_breakouts:
   Ethernet0: "4x10G"
 
-sonic_ports:
+sonic_ports_default_fec: none
+sonic_ports_default_mtu: 9216
+sonic_ports_default_speed: 100000
+sonic_ports_dict:
   Ethernet0:
     speed: 10000
     mtu: 1500
     vrf: VrfMpls
     ips:
     - 10.0.0.2/32
-# Uplink for pxe VLAN
-  Ethernet1:
-    speed: 10000
-  Ethernet2:
-    speed: 10000
-  Ethernet3:
-  speed: 10000
-  ips:
-  - 10.1.2.2/30
 # spine uplinks
   Ethernet112:
   Ethernet116:
@@ -43,6 +37,24 @@ sonic_running_cfg_ports:
     alias: Eth1/1(Port1)
     index: "1"
     lanes: "1"
+    parent_port: Ethernet0
+    speed: "10000"
+  Ethernet1:
+    alias: Eth1/2(Port1)
+    index: "1"
+    lanes: "2"
+    parent_port: Ethernet0
+    speed: "10000"
+  Ethernet2:
+    alias: Eth1/3(Port1)
+    index: "1"
+    lanes: "3"
+    parent_port: Ethernet0
+    speed: "10000"
+  Ethernet3:
+    alias: Eth1/4(Port1)
+    index: "1"
+    lanes: "4"
     parent_port: Ethernet0
     speed: "10000"
   Ethernet112:

--- a/partition/roles/sonic/test/data/exit/input.yaml
+++ b/partition/roles/sonic/test/data/exit/input.yaml
@@ -7,24 +7,56 @@ sonic_breakouts:
   Ethernet0: "4x10G"
 
 sonic_ports:
-- name: Ethernet0
-  speed: 10000
-  mtu: 1500
-  vrf: VrfMpls
-  ips:
-  - 10.0.0.2/32
+  Ethernet0:
+    speed: 10000
+    mtu: 1500
+    vrf: VrfMpls
+    ips:
+    - 10.0.0.2/32
 # Uplink for pxe VLAN
-- name: Ethernet1
-  speed: 10000
-- name: Ethernet2
-  speed: 10000
-- name: Ethernet3
+  Ethernet1:
+    speed: 10000
+  Ethernet2:
+    speed: 10000
+  Ethernet3:
   speed: 10000
   ips:
   - 10.1.2.2/30
 # spine uplinks
-- name: Ethernet112
-- name: Ethernet116
+  Ethernet112:
+  Ethernet116:
+
+sonic_running_cfg_breakouts:
+  Ethernet0:
+    brkout_mode: "4x10G"
+  Ethernet112:
+    brkout_mode: "1x100G[40G]"
+  Ethernet116:
+    brkout_mode: "1x100G[40G]"
+
+sonic_running_cfg_hwsku: Accton-AS7726-32X
+sonic_running_cfg_mac: e0:01:a6:e3:29:3c
+sonic_running_cfg_platform: x86_64-accton_as7726_32x-r0
+
+sonic_running_cfg_ports:
+  Ethernet0:
+    alias: Eth1/1(Port1)
+    index: "1"
+    lanes: "1"
+    parent_port: Ethernet0
+    speed: "10000"
+  Ethernet112:
+    alias: Eth29(Port29)
+    index: "29"
+    lanes: "113,114,115,116"
+    parent_port: Ethernet112
+    speed: "100000"
+  Ethernet116:
+    alias: Eth30(Port30)
+    index: "30"
+    lanes: "117,118,119,120"
+    parent_port: Ethernet116
+    speed: "100000"
 
 sonic_bgp_ports:
 - Ethernet112

--- a/partition/roles/sonic/test/data/exit/input.yaml
+++ b/partition/roles/sonic/test/data/exit/input.yaml
@@ -6,7 +6,6 @@ sonic_loopback_address: 10.0.0.1
 sonic_breakouts:
   Ethernet0: "4x10G"
 
-sonic_ports_default_fec: none
 sonic_ports_default_mtu: 9216
 sonic_ports_default_speed: 100000
 sonic_ports_dict:

--- a/partition/roles/sonic/test/data/exit/metal.yaml
+++ b/partition/roles/sonic/test/data/exit/metal.yaml
@@ -24,6 +24,12 @@ LOOPBACK_INTERFACE:
   Loopback0: {}
   Loopback0|10.0.0.1/32: {}
 
+MGMT_PORT:
+  eth0:
+    alias: "eth0"
+    admin_status: "up"
+    description: "Management Port"
+
 MGMT_VRF_CONFIG:
   vrf_global:
     mgmtVrfEnabled: "true"
@@ -32,8 +38,6 @@ INTERFACE:
   Ethernet0:
     vrf_name: "VrfMpls"
   Ethernet0|10.0.0.2/32: {}
-  Ethernet3: {}
-  Ethernet3|10.1.2.2/30: {}
   Ethernet112:
     ipv6_use_link_local_only: enable
   Ethernet116:
@@ -59,20 +63,26 @@ PORT:
     mtu: "1500"
     fec: "none"
   Ethernet1:
-    admin_status: up
+    alias: Eth1/2(Port1)
+    autoneg: "off"
+    index: "1"
+    lanes: "2"
+    parent_port: Ethernet0
     speed: "10000"
-    mtu: "9216"
-    fec: "none"
   Ethernet2:
-    admin_status: up
+    alias: Eth1/3(Port1)
+    autoneg: "off"
+    index: "1"
+    lanes: "3"
+    parent_port: Ethernet0
     speed: "10000"
-    mtu: "9216"
-    fec: "none"
   Ethernet3:
-    admin_status: up
+    alias: Eth1/4(Port1)
+    autoneg: "off"
+    index: "1"
+    lanes: "4"
+    parent_port: Ethernet0
     speed: "10000"
-    mtu: "9216"
-    fec: "none"
   Ethernet112:
     alias: Eth29(Port29)
     autoneg: "off"

--- a/partition/roles/sonic/test/data/exit/metal.yaml
+++ b/partition/roles/sonic/test/data/exit/metal.yaml
@@ -3,6 +3,9 @@ DEVICE_METADATA:
   localhost:
     docker_routing_config_mode: split
     hostname: "exit01"
+    hwsku: "Accton-AS7726-32X"
+    mac: "e0:01:a6:e3:29:3c"
+    platform: "x86_64-accton_as7726_32x-r0"
     type: "LeafRouter"
     frr_mgmt_framework_config: "true"
 
@@ -36,8 +39,21 @@ INTERFACE:
   Ethernet116:
     ipv6_use_link_local_only: enable
 
+BREAKOUT_CFG:
+  Ethernet0:
+    brkout_mode: "4x10G"
+  Ethernet112:
+    brkout_mode: "1x100G[40G]"
+  Ethernet116:
+    brkout_mode: "1x100G[40G]"
+
 PORT:
   Ethernet0:
+    alias: Eth1/1(Port1)
+    autoneg: "off"
+    index: "1"
+    lanes: "1"
+    parent_port: Ethernet0
     admin_status: up
     speed: "10000"
     mtu: "1500"
@@ -58,13 +74,23 @@ PORT:
     mtu: "9216"
     fec: "none"
   Ethernet112:
+    alias: Eth29(Port29)
+    autoneg: "off"
+    index: "29"
+    lanes: "113,114,115,116"
+    parent_port: Ethernet112
     admin_status: up
-    speed: "10000"
+    speed: "100000"
     mtu: "9216"
     fec: "none"
   Ethernet116:
+    alias: Eth30(Port30)
+    autoneg: "off"
+    index: "30"
+    lanes: "117,118,119,120"
+    parent_port: Ethernet116
     admin_status: up
-    speed: "10000"
+    speed: "100000"
     mtu: "9216"
     fec: "none"
 

--- a/partition/roles/sonic/test/data/mgmtleaf/frr.conf
+++ b/partition/roles/sonic/test/data/mgmtleaf/frr.conf
@@ -5,11 +5,11 @@ service integrated-vtysh-config
 !
 log syslog informational
 !
-interface Ethernet50
+interface Ethernet120
  ipv6 nd ra-interval 6
  no ipv6 nd suppress-ra
 !
-interface Ethernet51
+interface Ethernet124
  ipv6 nd ra-interval 6
  no ipv6 nd suppress-ra
 !
@@ -19,8 +19,8 @@ router bgp 420000000
  neighbor FABRIC peer-group
  neighbor FABRIC remote-as external
  neighbor FABRIC timers 1 3
- neighbor Ethernet50 interface peer-group FABRIC
- neighbor Ethernet51 interface peer-group FABRIC
+ neighbor Ethernet120 interface peer-group FABRIC
+ neighbor Ethernet124 interface peer-group FABRIC
  !
  address-family ipv4 unicast
   redistribute connected route-map DENY_MGMT

--- a/partition/roles/sonic/test/data/mgmtleaf/input.yaml
+++ b/partition/roles/sonic/test/data/mgmtleaf/input.yaml
@@ -10,7 +10,6 @@ sonic_ntpservers: ['1.2.3.4']
 sonic_breakouts:
   Ethernet0: "4x25G"
 
-sonic_ports_default_fec: none
 sonic_ports_default_mtu: 9000
 sonic_ports_default_speed: 1000
 sonic_ports_dict:

--- a/partition/roles/sonic/test/data/mgmtleaf/input.yaml
+++ b/partition/roles/sonic/test/data/mgmtleaf/input.yaml
@@ -13,20 +13,78 @@ sonic_breakouts:
 sonic_ports_default_speed: 1000
 sonic_ports_default_mtu: 9000
 sonic_ports:
-- name: Ethernet0
-- name: Ethernet1
-- name: Ethernet2
-- name: Ethernet3
-- name: Ethernet50
-  speed: 100000
-  mtu: 9216
-  fec: rs
-- name: Ethernet51
-  speed: 100000
+  Ethernet0:
+  Ethernet1:
+  Ethernet2:
+  Ethernet3:
+  Ethernet120:
+    speed: 100000
+    mtu: 9216
+    fec: rs
+  Ethernet124:
+    speed: 100000
+
+sonic_running_cfg_breakouts:
+  Ethernet0:
+    brkout_mode: "4x25G"
+  Ethernet4:
+    brkout_mode: "1x100G[40G]"
+  Ethernet120:
+    brkout_mode: "1x100G[40G]"
+  Ethernet124:
+    brkout_mode: "1x100G[40G]"
+
+sonic_running_cfg_hwsku: Accton-AS7726-32X
+sonic_running_cfg_mac: e0:01:a6:e3:29:3c
+sonic_running_cfg_platform: x86_64-accton_as7726_32x-r0
+
+sonic_running_cfg_ports:
+  Ethernet0:
+    alias: Eth1/1(Port1)
+    index: "1"
+    lanes: "1"
+    parent_port: Ethernet0
+    speed: "25000"
+  Ethernet1:
+    alias: Eth1/2(Port1)
+    index: '1'
+    lanes: '2'
+    parent_port: Ethernet0
+    speed: '25000'
+  Ethernet2:
+    alias: Eth1/3(Port1)
+    index: '1'
+    lanes: '3'
+    parent_port: Ethernet0
+    speed: '25000'
+  Ethernet3:
+    alias: Eth1/4(Port1)
+    index: '1'
+    lanes: '4'
+    parent_port: Ethernet0
+    speed: '25000'
+  Ethernet4:
+    alias: Eth2(Port2)
+    index: '2'
+    lanes: '5,6,7,8'
+    parent_port: Ethernet4
+    speed: '100000'
+  Ethernet120:
+    alias: Eth31(Port31)
+    index: '31'
+    lanes: '121,122,123,124'
+    parent_port: Ethernet120
+    speed: '100000'
+  Ethernet124:
+    alias: Eth32(Port32)
+    index: '32'
+    lanes: '125,126,127,128'
+    parent_port: Ethernet124
+    speed: '100000'
 
 sonic_bgp_ports:
-- Ethernet50
-- Ethernet51
+- Ethernet120
+- Ethernet124
 
 sonic_vlans:
 - id: 1

--- a/partition/roles/sonic/test/data/mgmtleaf/input.yaml
+++ b/partition/roles/sonic/test/data/mgmtleaf/input.yaml
@@ -10,9 +10,10 @@ sonic_ntpservers: ['1.2.3.4']
 sonic_breakouts:
   Ethernet0: "4x25G"
 
-sonic_ports_default_speed: 1000
+sonic_ports_default_fec: none
 sonic_ports_default_mtu: 9000
-sonic_ports:
+sonic_ports_default_speed: 1000
+sonic_ports_dict:
   Ethernet0:
   Ethernet1:
   Ethernet2:

--- a/partition/roles/sonic/test/data/mgmtleaf/metal.yaml
+++ b/partition/roles/sonic/test/data/mgmtleaf/metal.yaml
@@ -29,6 +29,12 @@ MGMT_INTERFACE:
   eth0|10.255.255.254/30:
     gwaddr: "10.255.255.253"
 
+MGMT_PORT:
+  eth0:
+    alias: "eth0"
+    admin_status: "up"
+    description: "Management Port"
+
 MGMT_VRF_CONFIG:
   vrf_global:
     mgmtVrfEnabled: "true"
@@ -57,7 +63,7 @@ PORT:
     lanes: "1"
     parent_port: Ethernet0
     admin_status: up
-    speed: "25000"
+    speed: "1000"
     mtu: "9000"
     fec: "none"
   Ethernet1:
@@ -67,7 +73,7 @@ PORT:
     lanes: "2"
     parent_port: Ethernet0
     admin_status: up
-    speed: "25000"
+    speed: "1000"
     mtu: "9000"
     fec: "none"
   Ethernet2:
@@ -77,7 +83,7 @@ PORT:
     lanes: "3"
     parent_port: Ethernet0
     admin_status: up
-    speed: "25000"
+    speed: "1000"
     mtu: "9000"
     fec: "none"
   Ethernet3:
@@ -87,7 +93,7 @@ PORT:
     lanes: "4"
     parent_port: Ethernet0
     admin_status: up
-    speed: "25000"
+    speed: "1000"
     mtu: "9000"
     fec: "none"
   Ethernet4:
@@ -97,8 +103,6 @@ PORT:
     lanes: "5,6,7,8"
     parent_port: Ethernet4
     speed: "100000"
-    mtu: "9000"
-    fec: "none"
   Ethernet120:
     alias: Eth31(Port31)
     autoneg: "off"

--- a/partition/roles/sonic/test/data/mgmtleaf/metal.yaml
+++ b/partition/roles/sonic/test/data/mgmtleaf/metal.yaml
@@ -3,6 +3,9 @@ DEVICE_METADATA:
   localhost:
     docker_routing_config_mode: split
     hostname: "r01mgmtleaf"
+    hwsku: "Accton-AS7726-32X"
+    mac: "e0:01:a6:e3:29:3c"
+    platform: "x86_64-accton_as7726_32x-r0"
     type: "LeafRouter"
     frr_mgmt_framework_config: "true"
 
@@ -31,38 +34,87 @@ MGMT_VRF_CONFIG:
     mgmtVrfEnabled: "true"
 
 INTERFACE:
-  Ethernet50:
+  Ethernet120:
     ipv6_use_link_local_only: enable
-  Ethernet51:
+  Ethernet124:
     ipv6_use_link_local_only: enable
+
+BREAKOUT_CFG:
+  Ethernet0:
+    brkout_mode: "4x25G"
+  Ethernet4:
+    brkout_mode: "1x100G[40G]"
+  Ethernet120:
+    brkout_mode: "1x100G[40G]"
+  Ethernet124:
+    brkout_mode: "1x100G[40G]"
 
 PORT:
   Ethernet0:
+    alias: Eth1/1(Port1)
+    autoneg: "off"
+    index: "1"
+    lanes: "1"
+    parent_port: Ethernet0
     admin_status: up
-    speed: "1000"
+    speed: "25000"
     mtu: "9000"
     fec: "none"
   Ethernet1:
+    alias: Eth1/2(Port1)
+    autoneg: "off"
+    index: "1"
+    lanes: "2"
+    parent_port: Ethernet0
     admin_status: up
-    speed: "1000"
+    speed: "25000"
     mtu: "9000"
     fec: "none"
   Ethernet2:
+    alias: Eth1/3(Port1)
+    autoneg: "off"
+    index: "1"
+    lanes: "3"
+    parent_port: Ethernet0
     admin_status: up
-    speed: "1000"
+    speed: "25000"
     mtu: "9000"
     fec: "none"
   Ethernet3:
+    alias: Eth1/4(Port1)
+    autoneg: "off"
+    index: "1"
+    lanes: "4"
+    parent_port: Ethernet0
     admin_status: up
-    speed: "1000"
+    speed: "25000"
     mtu: "9000"
     fec: "none"
-  Ethernet50:
+  Ethernet4:
+    alias: Eth2(Port2)
+    autoneg: "off"
+    index: "2"
+    lanes: "5,6,7,8"
+    parent_port: Ethernet4
+    speed: "100000"
+    mtu: "9000"
+    fec: "none"
+  Ethernet120:
+    alias: Eth31(Port31)
+    autoneg: "off"
+    index: "31"
+    lanes: "121,122,123,124"
+    parent_port: Ethernet120
     admin_status: up
     speed: "100000"
     mtu: "9216"
     fec: "rs"
-  Ethernet51:
+  Ethernet124:
+    alias: Eth32(Port32)
+    autoneg: "off"
+    index: "32"
+    lanes: "125,126,127,128"
+    parent_port: Ethernet124
     admin_status: up
     speed: "100000"
     mtu: "9000"

--- a/partition/roles/sonic/test/data/spine/frr.conf
+++ b/partition/roles/sonic/test/data/spine/frr.conf
@@ -5,11 +5,11 @@ service integrated-vtysh-config
 !
 log syslog informational
 !
-interface Ethernet50
+interface Ethernet120
  ipv6 nd ra-interval 6
  no ipv6 nd suppress-ra
 !
-interface Ethernet51
+interface Ethernet124
  ipv6 nd ra-interval 6
  no ipv6 nd suppress-ra
 !
@@ -19,8 +19,8 @@ router bgp 420000000
  neighbor FABRIC peer-group
  neighbor FABRIC remote-as external
  neighbor FABRIC timers 1 3
- neighbor Ethernet50 interface peer-group FABRIC
- neighbor Ethernet51 interface peer-group FABRIC
+ neighbor Ethernet120 interface peer-group FABRIC
+ neighbor Ethernet124 interface peer-group FABRIC
  !
  address-family ipv4 unicast
   redistribute connected route-map LOOPBACKS

--- a/partition/roles/sonic/test/data/spine/input.yaml
+++ b/partition/roles/sonic/test/data/spine/input.yaml
@@ -8,9 +8,10 @@ sonic_bgp_ports:
 - Ethernet120
 - Ethernet124
 
-sonic_ports_default_speed: 100000
+sonic_ports_default_fec: none
 sonic_ports_default_mtu: 9216
-sonic_ports:
+sonic_ports_default_speed: 100000
+sonic_ports_dict:
   Ethernet120:
   Ethernet124:
 

--- a/partition/roles/sonic/test/data/spine/input.yaml
+++ b/partition/roles/sonic/test/data/spine/input.yaml
@@ -8,7 +8,6 @@ sonic_bgp_ports:
 - Ethernet120
 - Ethernet124
 
-sonic_ports_default_fec: none
 sonic_ports_default_mtu: 9216
 sonic_ports_default_speed: 100000
 sonic_ports_dict:

--- a/partition/roles/sonic/test/data/spine/input.yaml
+++ b/partition/roles/sonic/test/data/spine/input.yaml
@@ -5,14 +5,38 @@ sonic_loopback_address: 10.0.0.1
 sonic_asn: 420000000
 
 sonic_bgp_ports:
-- Ethernet50
-- Ethernet51
+- Ethernet120
+- Ethernet124
 
 sonic_ports_default_speed: 100000
 sonic_ports_default_mtu: 9216
 sonic_ports:
-- name: Ethernet50
-- name: Ethernet51
+  Ethernet120:
+  Ethernet124:
+
+sonic_running_cfg_breakouts:
+  Ethernet120:
+    brkout_mode: "1x100G[40G]"
+  Ethernet124:
+    brkout_mode: "1x100G[40G]"
+
+sonic_running_cfg_hwsku: Accton-AS7726-32X
+sonic_running_cfg_mac: e0:01:a6:e3:29:3c
+sonic_running_cfg_platform: x86_64-accton_as7726_32x-r0
+
+sonic_running_cfg_ports:
+  Ethernet120:
+    alias: Eth31(Port31)
+    index: '31'
+    lanes: '121,122,123,124'
+    parent_port: Ethernet120
+    speed: '100000'
+  Ethernet124:
+    alias: Eth32(Port32)
+    index: '32'
+    lanes: '125,126,127,128'
+    parent_port: Ethernet124
+    speed: '100000'
 
 sonic_frr_l2vpn_evpn: true
 sonic_frr_route_map:

--- a/partition/roles/sonic/test/data/spine/metal.yaml
+++ b/partition/roles/sonic/test/data/spine/metal.yaml
@@ -3,6 +3,9 @@ DEVICE_METADATA:
   localhost:
     docker_routing_config_mode: split
     hostname: "spine01"
+    hwsku: "Accton-AS7726-32X"
+    mac: "e0:01:a6:e3:29:3c"
+    platform: "x86_64-accton_as7726_32x-r0"
     type: "LeafRouter"
     frr_mgmt_framework_config: "true"
 
@@ -26,18 +29,34 @@ MGMT_VRF_CONFIG:
     mgmtVrfEnabled: "true"
 
 INTERFACE:
-  Ethernet50:
+  Ethernet120:
     ipv6_use_link_local_only: enable
-  Ethernet51:
+  Ethernet124:
     ipv6_use_link_local_only: enable
 
+BREAKOUT_CFG:
+  Ethernet120:
+    brkout_mode: "1x100G[40G]"
+  Ethernet124:
+    brkout_mode: "1x100G[40G]"
+
 PORT:
-  Ethernet50:
+  Ethernet120:
+    alias: Eth31(Port31)
+    autoneg: "off"
+    index: "31"
+    lanes: "121,122,123,124"
+    parent_port: Ethernet120
     admin_status: up
     speed: "100000"
     mtu: "9216"
     fec: "none"
-  Ethernet51:
+  Ethernet124:
+    alias: Eth32(Port32)
+    autoneg: "off"
+    index: "32"
+    lanes: "125,126,127,128"
+    parent_port: Ethernet124
     admin_status: up
     speed: "100000"
     mtu: "9216"

--- a/partition/roles/sonic/test/data/spine/metal.yaml
+++ b/partition/roles/sonic/test/data/spine/metal.yaml
@@ -24,6 +24,12 @@ LOOPBACK_INTERFACE:
   Loopback0: {}
   Loopback0|10.0.0.1/32: {}
 
+MGMT_PORT:
+  eth0:
+    alias: "eth0"
+    admin_status: "up"
+    description: "Management Port"
+
 MGMT_VRF_CONFIG:
   vrf_global:
     mgmtVrfEnabled: "true"


### PR DESCRIPTION
Previously, our method involved persisting the entirety of the running configuration into `/etc/sonic/config_db.json` by running `config save` in a task. This approach led to undesired configurations being retained, especially noticeable after a switch reboot. A key example of such undesired configurations arises from `metal-core`.

To refine this, we have now transitioned to a selective persistence strategy. Instead of saving the entire running configuration, only crucial segments are extracted and stored. Specifically, these segments relate to the breakout and port configuration. This approach ensures a cleaner and more focused `/etc/sonic/config_db.json`, mitigating the presence of unintended configurations.