### PR TITLE
Ensure AgentX is enabled on leaves

### DIFF
--- a/partition/roles/metal-core/handlers/main.yaml
+++ b/partition/roles/metal-core/handlers/main.yaml
@@ -1,0 +1,5 @@
+---
+- name: restart bgp
+  systemd:
+    name: bgp
+    state: restarted

--- a/partition/roles/metal-core/tasks/main.yaml
+++ b/partition/roles/metal-core/tasks/main.yaml
@@ -14,6 +14,10 @@
       - metal_core_image_tag is defined
       - metal_core_rack_id is not none
 
+- name: SONiC specific configurations
+  ansible.builtin.import_tasks: sonic.yaml
+  when: metal_stack_switch_os_is_sonic
+
 - name: create gRPC certs directory
   file:
     path: "{{ metal_core_grpc_cert_dir }}"

--- a/partition/roles/metal-core/tasks/sonic.yaml
+++ b/partition/roles/metal-core/tasks/sonic.yaml
@@ -1,0 +1,25 @@
+---
+- name: Check that /etc/sonic/frr/frr.conf exists
+  ansible.builtin.stat:
+    path: /etc/sonic/frr/frr.conf
+  register: stat_result
+
+- name: Create initial frr.conf
+  ansible.builtin.template:
+    src: frr.conf.j2
+    dest: /etc/sonic/frr/frr.conf
+    mode: '0644'
+    owner: frr
+    group: frr
+  when: not stat_result.stat.exists
+  notify: restart bgp
+
+# Cannot be configured in a running frr instance
+- name: Ensure agentx is configured
+  ansible.builtin.lineinfile:
+    path: /etc/sonic/frr/frr.conf
+    firstmatch: true
+    insertafter: "^!$"
+    line: agentx
+  when: stat_result.stat.exists
+  notify: restart bgp

--- a/partition/roles/metal-core/templates/frr.conf.j2
+++ b/partition/roles/metal-core/templates/frr.conf.j2
@@ -1,0 +1,8 @@
+! The frr version is not rendered since it seems to be optional.
+frr defaults datacenter
+hostname {{ ansible_hostname }}
+password zebra
+enable password zebra
+!
+agentx
+!


### PR DESCRIPTION
Newer versions of Edgecore SONiC enable AgentX protocol support by default. It is hardcoded in the supervisor configuration in the bgp container and once enabled, it cannot be unconfigured anymore. As result, we activate it on every SONiC distribution.