### PR TITLE
Move global options before subnets configuration

### DIFF
--- a/partition/roles/dhcp/templates/dhcpd.conf.j2
+++ b/partition/roles/dhcp/templates/dhcpd.conf.j2
@@ -6,6 +6,13 @@ max-lease-time {{ dhcp_max_lease_time }};
 
 log-facility local7;
 
+{% for option in dhcp_global_options %}
+option {{ option }};
+{% endfor %}
+{% for deny in dhcp_global_deny_list %}
+  deny {{ deny }};
+{% endfor -%}
+
 {% for subnet in dhcp_subnets %}
 {% if subnet.comment | default("") %}
 # {{ subnet.comment }}
@@ -21,14 +28,7 @@ subnet {{ subnet.network }} netmask {{ subnet.netmask }} {
   deny {{ deny }};
 {% endfor %}
 }
-{% endfor %}
-
-{% for option in dhcp_global_options %}
-option {{ option }};
-{% endfor %}
-{% for deny in dhcp_global_deny_list %}
-  deny {{ deny }};
-{% endfor %}
+{% endfor -%}
 
 {% if dhcp_static_hosts is defined %}
 include "/etc/dhcp/dhcpd.hosts";

--- a/partition/roles/dhcp/test/__init__.py
+++ b/partition/roles/dhcp/test/__init__.py
@@ -1,6 +1,0 @@
-import os
-
-
-def read_template_file(name):
-    with open(os.path.join(os.path.dirname(__file__), "..", "templates", name), 'r') as f:
-        return f.read()

--- a/partition/roles/dhcp/test/template_test.py
+++ b/partition/roles/dhcp/test/template_test.py
@@ -1,8 +1,13 @@
+import os
 import unittest
-
-from test import read_template_file
+from textwrap import dedent
 
 from ansible.template import Templar
+
+
+def read_template_file(name):
+    with open(os.path.join(os.path.dirname(__file__), "..", "templates", name), 'r') as f:
+        return f.read()
 
 
 class DHCPD(unittest.TestCase):
@@ -28,24 +33,25 @@ class DHCPD(unittest.TestCase):
             hostvars=dict(mgmt01=dict(switch_mgmt_ip="3.3.3.3"), mgmt02=dict(switch_mgmt_ip="4.4.4.4")),
         ))
 
-        res = templar.template(t)
+        result = templar.template(t)
 
-        self.assertIn("""
-authoritative;
-
-default-lease-time 600;
-max-lease-time 600;
-
-log-facility local7;
-
-# testing
-subnet 1.2.3.4 netmask 24 {
-  range 1 2;
-  option routers 2.2.2.2;
-  option domain-name-servers 1.1.1.1, 8.8.8.8;
-  deny unknown-clients;
-}
-""".strip(), res.strip())
+        self.assertEqual(dedent("""\
+        # indicate that the DHCP server should send DHCPNAK messages to misconfigured client
+        authoritative;
+        
+        default-lease-time 600;
+        max-lease-time 600;
+        
+        log-facility local7;
+        
+        # testing
+        subnet 1.2.3.4 netmask 24 {
+          range 1 2;
+          option routers 2.2.2.2;
+          option domain-name-servers 1.1.1.1, 8.8.8.8;
+          deny unknown-clients;
+        }
+        """), result)
 
     def test_dhcpd_hosts_config_template(self):
         t = read_template_file("dhcpd.hosts.j2")
@@ -67,18 +73,19 @@ subnet 1.2.3.4 netmask 24 {
             ],
         ))
 
-        res = templar.template(t)
+        result = templar.template(t)
 
-        self.assertEqual("""
-host test1 {
-  hardware ethernet aa:bb:cc:dd:ee:ef;
-  fixed-address 10.1.2.1;
-  option test1;
-}
-
-host test2 {
-  hardware ethernet aa:bb:cc:dd:ee:ff;
-  fixed-address 10.1.2.2;
-  option test2;
-}
-""".strip(), res.strip())
+        self.assertEqual(dedent("""\
+        host test1 {
+          hardware ethernet aa:bb:cc:dd:ee:ef;
+          fixed-address 10.1.2.1;
+          option test1;
+        }
+        
+        host test2 {
+          hardware ethernet aa:bb:cc:dd:ee:ff;
+          fixed-address 10.1.2.2;
+          option test2;
+        }
+        
+        """), result)


### PR DESCRIPTION
Some option can only be configured globally but have to be defined before they can be used as option for a subnet, e.g. `option ztp_provisioning_script_url code`