### PR TITLE
Extend max shoot kubeconfig expiration for gardener-apiserver.

### DIFF
--- a/control-plane/roles/gardener/README.md
+++ b/control-plane/roles/gardener/README.md
@@ -38,8 +38,6 @@ Check out the Gardener project for further documentation on [gardener.cloud](htt
 | gardener_kube_apiserver_kubeconfig_path                |           | The acts on multiple Kubernetes APIs, this is where it puts the kubeconfig of the Gardener Kubernetes API                     |
 | gardener_local_tmp_dir                                 |           | The acts on multiple Kubernetes APIs, this is a local folder in the deployment container to store the kubeconfigs (ephemeral) |
 
-
-
 ### Virtual Garden
 
 These variables are related to spinning up the virtual garden, a dedicated kube-apiserver, kube-controller-manager and ETCD to host all Gardener resources. This one will have no worker nodes and cannot schedule pods.

--- a/control-plane/roles/gardener/README.md
+++ b/control-plane/roles/gardener/README.md
@@ -16,6 +16,7 @@ Check out the Gardener project for further documentation on [gardener.cloud](htt
 | gardener_apiserver_vpa                                 |           | Enables the VPA for the gardener-apiserver                                                                                    |
 | gardener_apiserver_resources                           |           | Set custom resource definitions for the gardener-apiserver                                                                    |
 | gardener_apiserver_feature_gates                       |           | Sets features gates for the gardener-apiserver                                                                                |
+| gardener_apiserver_shoot_kubeconfig_max_expiration     |           | Max shoot kubeconfig expiration for the gardener-apiserver                                                                    |
 | gardener_controller_manager_resources                  |           | Set custom resource definitions for the gardener-controller-manager                                                           |
 | gardener_scheduler_resources                           |           | Set custom resource definitions for the gardener-scheduler                                                                    |
 | gardener_dns_domain                                    |           | Specifies the DNS domain on which the Gardener will manage DNS entries                                                        |
@@ -36,6 +37,8 @@ Check out the Gardener project for further documentation on [gardener.cloud](htt
 | gardener_kube_api_server_kubeconfig                    |           | The kubeconfig for the Gardener Kubernetes API (virtual garden apiserver)                                                     |
 | gardener_kube_apiserver_kubeconfig_path                |           | The acts on multiple Kubernetes APIs, this is where it puts the kubeconfig of the Gardener Kubernetes API                     |
 | gardener_local_tmp_dir                                 |           | The acts on multiple Kubernetes APIs, this is a local folder in the deployment container to store the kubeconfigs (ephemeral) |
+
+
 
 ### Virtual Garden
 

--- a/control-plane/roles/gardener/defaults/main/gardener.yaml
+++ b/control-plane/roles/gardener/defaults/main/gardener.yaml
@@ -5,6 +5,7 @@ gardener_component_image_vector_overwrite:
 gardener_apiserver_replicas: 1
 gardener_apiserver_vpa: true
 gardener_apiserver_feature_gates: {}
+gardener_apiserver_shoot_kubeconfig_max_expiration: "8760h"
 
 gardener_apiserver_resources:
   requests:

--- a/control-plane/roles/gardener/templates/gardener-control-plane-values.j2
+++ b/control-plane/roles/gardener/templates/gardener-control-plane-values.j2
@@ -47,6 +47,9 @@ global:
     kubeconfig: |
       {{ gardener_kube_api_server_kubeconfig | indent(width=6, first=false) }}
 
+    shootAdminKubeconfigMaxExpiration: {{ gardener_apiserver_shoot_kubeconfig_max_expiration }}
+    shootViewerKubeconfigMaxExpiration: {{ gardener_apiserver_shoot_kubeconfig_max_expiration }}
+
     vpa: {{ gardener_apiserver_vpa }}
     # this requires the Hvpa resource in autoscaling.k8s.io/v1alpha1, which is not in the GKE cluster... how to actually use this?
     # hvpa:


### PR DESCRIPTION
Currently this is limited to 24h.