### PR TITLE
Remove ACL webhook image from image vector mapping.

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -132,7 +132,6 @@ metal_stack_release:
     gardener_metrics_exporter_image_tag: "docker-images.third-party.gardener.metrics-exporter.tag"
     gardener_metrics_exporter_image_name: "docker-images.third-party.gardener.metrics-exporter.name"
     gardener_extension_acl_image_name: "docker-images.third-party.gardener.acl-extension.name"
-    gardener_extension_acl_webhook_image_name: "docker-images.third-party.gardener.acl-extension.webhook"
     gardener_extension_acl_image_tag: "docker-images.third-party.gardener.acl-extension.tag"
     # helm-charts
     metal_helm_chart_version: "helm-charts.metal-stack.metal-control-plane.version"


### PR DESCRIPTION
Was removed in v1.0.0 of the extension.