### PR TITLE
Wait for the Kubernetes API server of the virtual garden to be externally reachable

### DIFF
--- a/control-plane/roles/gardener/tasks/virtual_garden.yaml
+++ b/control-plane/roles/gardener/tasks/virtual_garden.yaml
@@ -42,3 +42,9 @@
   copy:
     dest: "{{ gardener_kube_apiserver_kubeconfig_path }}"
     content: "{{ lookup('k8s', api_version='v1', kind='Secret', namespace='garden', resource_name='garden-kubeconfig-for-admin').get('data', {}).get('kubeconfig') | b64decode }}"
+
+- name: Wait for garden-kube-apiserver
+  wait_for:
+    host: "{{ gardener_virtual_api_server_public_dns }}"
+    port: "443"
+    timeout: 60


### PR DESCRIPTION
Without waiting for the successful allocation of the LoadBalancer IP address and DNS record, we may encounter a race condition.