### PR TITLE
Adaptions for g/g 1.77

### DIFF
--- a/control-plane/roles/gardener/tasks/gardener.yaml
+++ b/control-plane/roles/gardener/tasks/gardener.yaml
@@ -25,12 +25,13 @@
       metadata:
         namespace: garden
         annotations:
+          helm.sh/resource-policy: keep
           dns.gardener.cloud/domain: "{{ gardener_dns_domain }}"
           dns.gardener.cloud/provider: "{{ gardener_dns_provider }}"
         labels:
           app: gardener
           gardener.cloud/role: "{{ item }}"
-        name: "{{ item }}-cluster-metal-stack"
+        name: "{{ item }}-cluster-{{ gardener_dns_domain | regex_replace('\\.', '-') }}"
       type: Opaque
       data: "{{ gardener_dns_credentials }}"
     kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"

--- a/control-plane/roles/gardener/tasks/gardener.yaml
+++ b/control-plane/roles/gardener/tasks/gardener.yaml
@@ -34,7 +34,7 @@
         name: "{{ item }}-cluster-metal-stack-dev"
       type: Opaque
       data:
-        serviceaccount.json: "{{ gardener_dns_credentials | to_json }}"
+        serviceaccount.json: "{{ gardener_dns_credentials | to_json | b64encode }}"
     kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"
   loop:
     - internal-domain

--- a/control-plane/roles/gardener/tasks/gardener.yaml
+++ b/control-plane/roles/gardener/tasks/gardener.yaml
@@ -17,6 +17,46 @@
           app: gardener
     kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"
 
+- name: Deploy internal domain secret (in virtual apiserver)
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        namespace: garden
+        annotations:
+          helm.sh/resource-policy: keep
+          dns.gardener.cloud/domain: "{{ gardener_dns_domain }}"
+          dns.gardener.cloud/provider: "{{ gardener_dns_provider }}"
+        labels:
+          app: gardener
+          gardener.cloud/role: internal-domain
+        name: internal-domain-cluster-metal-stack-dev
+      type: Opaque
+      data:
+        serviceaccount.json: "{{ gardener_dns_credentials | to_json }}"
+    kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"
+
+- name: Deploy default domain secret (in virtual apiserver)
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        namespace: garden
+        annotations:
+          helm.sh/resource-policy: keep
+          dns.gardener.cloud/domain: "{{ gardener_dns_domain }}"
+          dns.gardener.cloud/provider: "{{ gardener_dns_provider }}"
+        labels:
+          app: gardener
+          gardener.cloud/role: default-domain
+        name: default-domain-cluster-metal-stack-dev
+      type: Opaque
+      data:
+        serviceaccount.json: "{{ gardener_dns_credentials | to_json }}"
+    kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"
+
 - name: Deploy Gardener Control Plane (in virtual apiserver)
   include_role:
     name: ansible-common/roles/helm-chart

--- a/control-plane/roles/gardener/tasks/gardener.yaml
+++ b/control-plane/roles/gardener/tasks/gardener.yaml
@@ -31,7 +31,7 @@
         labels:
           app: gardener
           gardener.cloud/role: "{{ item }}"
-        name: "{{ item }}-cluster-{{ gardener_dns_domain | regex_replace('\\.', '-') }}"
+        name: "{{ item }}-{{ gardener_dns_domain | regex_replace('\\.', '-') }}"
       type: Opaque
       data: "{{ gardener_dns_credentials }}"
     kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"

--- a/control-plane/roles/gardener/tasks/gardener.yaml
+++ b/control-plane/roles/gardener/tasks/gardener.yaml
@@ -17,7 +17,7 @@
           app: gardener
     kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"
 
-- name: Deploy internal domain secret (in virtual apiserver)
+- name: Deploy domain secrets (in virtual apiserver)
   k8s:
     definition:
       apiVersion: v1
@@ -30,32 +30,15 @@
           dns.gardener.cloud/provider: "{{ gardener_dns_provider }}"
         labels:
           app: gardener
-          gardener.cloud/role: internal-domain
-        name: internal-domain-cluster-metal-stack-dev
+          gardener.cloud/role: "{{ item }}"
+        name: "{{ item }}-cluster-metal-stack-dev"
       type: Opaque
       data:
         serviceaccount.json: "{{ gardener_dns_credentials | to_json }}"
     kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"
-
-- name: Deploy default domain secret (in virtual apiserver)
-  k8s:
-    definition:
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        namespace: garden
-        annotations:
-          helm.sh/resource-policy: keep
-          dns.gardener.cloud/domain: "{{ gardener_dns_domain }}"
-          dns.gardener.cloud/provider: "{{ gardener_dns_provider }}"
-        labels:
-          app: gardener
-          gardener.cloud/role: default-domain
-        name: default-domain-cluster-metal-stack-dev
-      type: Opaque
-      data:
-        serviceaccount.json: "{{ gardener_dns_credentials | to_json }}"
-    kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"
+  loop:
+    - internal-domain
+    - default-domain
 
 - name: Deploy Gardener Control Plane (in virtual apiserver)
   include_role:

--- a/control-plane/roles/gardener/tasks/gardener.yaml
+++ b/control-plane/roles/gardener/tasks/gardener.yaml
@@ -25,13 +25,12 @@
       metadata:
         namespace: garden
         annotations:
-          helm.sh/resource-policy: keep
           dns.gardener.cloud/domain: "{{ gardener_dns_domain }}"
           dns.gardener.cloud/provider: "{{ gardener_dns_provider }}"
         labels:
           app: gardener
           gardener.cloud/role: "{{ item }}"
-        name: "{{ item }}-cluster-metal-stack-dev"
+        name: "{{ item }}-cluster-metal-stack"
       type: Opaque
       data: "{{ gardener_dns_credentials }}"
     kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"

--- a/control-plane/roles/gardener/tasks/gardener.yaml
+++ b/control-plane/roles/gardener/tasks/gardener.yaml
@@ -33,8 +33,7 @@
           gardener.cloud/role: "{{ item }}"
         name: "{{ item }}-cluster-metal-stack-dev"
       type: Opaque
-      data:
-        serviceaccount.json: "{{ gardener_dns_credentials | to_json | b64encode }}"
+      data: "{{ gardener_dns_credentials | to_json }}"
     kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"
     apply: true
   loop:

--- a/control-plane/roles/gardener/tasks/gardener.yaml
+++ b/control-plane/roles/gardener/tasks/gardener.yaml
@@ -33,7 +33,7 @@
           gardener.cloud/role: "{{ item }}"
         name: "{{ item }}-cluster-metal-stack-dev"
       type: Opaque
-      data: "{{ gardener_dns_credentials | to_json }}"
+      data: "{{ gardener_dns_credentials }}"
     kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"
     apply: true
   loop:

--- a/control-plane/roles/gardener/tasks/gardener.yaml
+++ b/control-plane/roles/gardener/tasks/gardener.yaml
@@ -36,6 +36,7 @@
       data:
         serviceaccount.json: "{{ gardener_dns_credentials | to_json | b64encode }}"
     kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"
+    apply: true
   loop:
     - internal-domain
     - default-domain

--- a/control-plane/roles/gardener/tasks/seed.yaml
+++ b/control-plane/roles/gardener/tasks/seed.yaml
@@ -121,16 +121,3 @@
       status: "True"
       type: GardenletReady
     wait_timeout: 180
-
-- name: Wait until Seed cluster has been bootstrapped successfully
-  kubernetes.core.k8s_info:
-    api_version: "core.gardener.cloud/v1beta1"
-    kind: Seed
-    name: "{{ gardener_soil_name }}"
-    kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"
-    wait: yes
-    wait_condition:
-      reason: BootstrappingSucceeded
-      status: "True"
-      type: Bootstrapped
-    wait_timeout: 180

--- a/control-plane/roles/gardener/templates/gardener-control-plane-values.j2
+++ b/control-plane/roles/gardener/templates/gardener-control-plane-values.j2
@@ -118,16 +118,6 @@ global:
     kubeconfig: |
       {{ gardener_kube_api_server_kubeconfig | indent(width=6, first=false) }}
 
-  internalDomain:
-    provider: "{{ gardener_dns_provider }}"
-    domain: "{{ gardener_dns_domain }}"
-    credentials: {{ gardener_dns_credentials | to_json }}
-
-  defaultDomains:
-  - provider: "{{ gardener_dns_provider }}"
-    domain: "{{ gardener_dns_domain }}"
-    credentials: {{ gardener_dns_credentials | to_json }}
-
   deployment:
    virtualGarden:
      enabled: true


### PR DESCRIPTION
Adaptions for g/g 1.77:

- Domain secrets were removed from Gardener controlplane chart (old secret names are maintained, see [here](https://github.com/gardener/gardener/pull/8308/files#diff-8e92b9a980be5440ffc129c104e8dbdc4bbf89602ff54663d5c65151351541caL7))
- Bootstrap condition was removed from seed resource
