### PR TITLE
Fix OIDC issuer and client ID default to `None`.

### DIFF
--- a/control-plane/roles/gardener/templates/kube-apiserver-values.j2
+++ b/control-plane/roles/gardener/templates/kube-apiserver-values.j2
@@ -8,8 +8,12 @@ apiServer:
   serviceName: garden-kube-apiserver
 
 oidc:
+{% if gardener_virtual_api_oidc_issuer_url %}
   issuerURL: {{ gardener_virtual_api_oidc_issuer_url }}
+{% endif %}
+{% if gardener_virtual_api_oidc_client_id %}
   clientID: {{ gardener_virtual_api_oidc_client_id }}
+{% endif %}
 {% if gardener_virtual_api_oidc_username_claim %}
   usernameClaim: {{ gardener_virtual_api_oidc_username_claim }}
 {% endif %}


### PR DESCRIPTION
Otherwise we create a Deployment of the api-server that will not start up anymore:

```
I0315 09:50:31.862781       1 flags.go:64] FLAG: --oidc-ca-file=""
I0315 09:50:31.862786       1 flags.go:64] FLAG: --oidc-client-id="None"
I0315 09:50:31.862792       1 flags.go:64] FLAG: --oidc-groups-claim=""
I0315 09:50:31.862798       1 flags.go:64] FLAG: --oidc-groups-prefix=""
I0315 09:50:31.862803       1 flags.go:64] FLAG: --oidc-issuer-url="None"
```