### PR TITLE
Allow serving additional files along with ztp.sh.

### DIFF
--- a/partition/roles/ztp/README.md
+++ b/partition/roles/ztp/README.md
@@ -12,3 +12,4 @@ Configures a server for providing zero-touch-provisioning scripts for switches.
 | ztp_port             |           | the port to serve ztp scripts on.                           |
 | ztp_authorized_keys  | yes       | the authorized keys that should be installed by ztp.        |
 | ztp_admin_user       |           | the user for which the authorized keys will be provisioned. |
+| ztp_additional_files |           | puts additional files into serve directory.                 |

--- a/partition/roles/ztp/defaults/main/main.yaml
+++ b/partition/roles/ztp/defaults/main/main.yaml
@@ -5,3 +5,7 @@ ztp_authorized_keys:
 ztp_admin_user: admin
 
 ztp_port: 8080
+
+ztp_additional_files: []
+# - name: foo.sh
+#   data: echo

--- a/partition/roles/ztp/tasks/main.yaml
+++ b/partition/roles/ztp/tasks/main.yaml
@@ -10,6 +10,7 @@
       - ztp_nginx_image_name is defined
       - ztp_nginx_image_tag is defined
       - ztp_authorized_keys is not none
+      - "'ztp.sh' not in ztp_additional_files | map(attribute='name')"
 
 - name: create ztp config directory
   file:
@@ -21,6 +22,15 @@
     src: "ztp.sh.j2"
     dest: "{{ ztp_host_dir_path }}/config/ztp.sh"
     mode: 0644
+
+- name: copy additional contents
+  copy:
+    dest: "{{ ztp_host_dir_path }}/config/{{ item.name }}"
+    content: "{{ item.data }}"
+    mode: 0644
+  loop: "{{ ztp_additional_files }}"
+  loop_control:
+    label: "{{ item.name }}"
 
 - name: deploy server for serving ztp.sh
   include_role:


### PR DESCRIPTION
We use this for providing Cumulus and SONiC ZTP files at the same time.