### PR TITLE
Sag gratuitous arp override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .shoot*
 __pycache__
 .Trash*
+*~

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -171,6 +171,13 @@ VLAN_INTERFACE:
   {% for vlan in sonic_vlans %}
   {% if vlan.vrf is defined %}
   Vlan{{ vlan.id }}:
+    {% if sonic_sag is defined and sonic_sag.vlans is defined %}
+    {% for sag_vlan in sonic_sag.vlans %}
+    {% if vlan.id == sag_vlan.id %}
+    "grat_arp_force_override": "enabled"
+    {% endif %}
+    {% endfor %}
+    {% endif %}
     vrf_name: "{{ vlan.vrf }}"
   {% else %}
   Vlan{{ vlan.id }}: {}

--- a/partition/roles/sonic/test/data/l2_leaf/metal.yaml
+++ b/partition/roles/sonic/test/data/l2_leaf/metal.yaml
@@ -267,6 +267,7 @@ VLAN_INTERFACE:
   Vlan1000: {}
   Vlan1000|192.168.255.1/24: {}
   Vlan1001:
+    "grat_arp_force_override": "enabled"
     vrf_name: "Vrf46"
 
 VLAN_MEMBER:


### PR DESCRIPTION
Set the option to accept gratuitous arp on Vlans with SAG enabled as recommended by Edgecore; see https://support.edge-core.com/hc/en-us/articles/6840823990169--Enterprise-SONiC-SAG-static-anycast-gateway

Only implemented for VLANs in a VRF since this is the current use case.
