### PR TITLE
Use ansible_host for hostname on leaves

### DIFF
--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -3,7 +3,7 @@
 DEVICE_METADATA:
   localhost:
     docker_routing_config_mode: "{{ sonic_docker_routing_config_mode }}"
-    hostname: "{{ inventory_hostname }}"
+    hostname: "{{ ansible_host }}"
     hwsku: "{{ sonic_running_cfg_hwsku }}"
     mac: "{{ sonic_running_cfg_mac }}"
     platform: "{{ sonic_running_cfg_platform }}"

--- a/partition/roles/sonic/test/data/exit/input.yaml
+++ b/partition/roles/sonic/test/data/exit/input.yaml
@@ -1,5 +1,6 @@
 ---
 inventory_hostname: exit01
+ansible_host: "{{ inventory_hostname }}"
 sonic_asn: 4200000000
 sonic_loopback_address: 10.0.0.1
 

--- a/partition/roles/sonic/test/data/l2_leaf/input.yaml
+++ b/partition/roles/sonic/test/data/l2_leaf/input.yaml
@@ -1,5 +1,6 @@
 ---
 inventory_hostname: l2leaf01
+ansible_host: "{{ inventory_hostname }}"
 sonic_asn: 4200000000
 sonic_loopback_address: 10.0.0.1
 

--- a/partition/roles/sonic/test/data/mgmtleaf/input.yaml
+++ b/partition/roles/sonic/test/data/mgmtleaf/input.yaml
@@ -1,6 +1,6 @@
 ---
 inventory_hostname: r01mgmtleaf
-
+ansible_host: "{{ inventory_hostname }}"
 sonic_mgmtif_ip: '10.255.255.254/30'
 sonic_mgmtif_gateway: 10.255.255.253
 

--- a/partition/roles/sonic/test/data/sonic-vs/input.yaml
+++ b/partition/roles/sonic/test/data/sonic-vs/input.yaml
@@ -1,5 +1,6 @@
 ---
 inventory_hostname: sonic-vs
+ansible_host: "{{ inventory_hostname }}"
 sonic_asn: 4200000000
 sonic_loopback_address: 10.0.0.1
 

--- a/partition/roles/sonic/test/data/spine/input.yaml
+++ b/partition/roles/sonic/test/data/spine/input.yaml
@@ -1,6 +1,6 @@
 ---
 inventory_hostname: spine01
-
+ansible_host: "{{ inventory_hostname }}"
 sonic_loopback_address: 10.0.0.1
 sonic_asn: 420000000
 


### PR DESCRIPTION
This enables explicitly setting a hostname for a leaf in cases where `inventory_hostname` would cause conflicts (e.g. switch replacement).