### PR TITLE
Allow to provide the imageVectorOverwrite for the cilium extension

### DIFF
--- a/control-plane/roles/gardener/README.md
+++ b/control-plane/roles/gardener/README.md
@@ -112,7 +112,7 @@ This includes the metal-stack extension provider called [gardener-extension-prov
 | gardener_extension_provider_metal_image_pull_policy          |           | Sets the image pull policy for components deployed through this extension controller.                                                       |
 | gardener_extension_provider_metal_image_pull_secret          |           | Provide image pull secrets for deployed containers                                                                                          |
 | gardener_cert_management_issuer_private_key                  |           | The Let's Encrypt private key used by the cert-management extension controller to setup signed certificates                                 |
-| gardener_extension_networking_cilium_vector_overwrite_image_tag | | Allows overriding the image tag of the image vector images for the networking cilium extension  |
+| gardener_extension_networking_cilium_image_vector_overwrite  |           | Allows overriding the image vector for the networking cilium extension                                                                      |
 
 ### Certificates
 

--- a/control-plane/roles/gardener/README.md
+++ b/control-plane/roles/gardener/README.md
@@ -112,6 +112,7 @@ This includes the metal-stack extension provider called [gardener-extension-prov
 | gardener_extension_provider_metal_image_pull_policy          |           | Sets the image pull policy for components deployed through this extension controller.                                                       |
 | gardener_extension_provider_metal_image_pull_secret          |           | Provide image pull secrets for deployed containers                                                                                          |
 | gardener_cert_management_issuer_private_key                  |           | The Let's Encrypt private key used by the cert-management extension controller to setup signed certificates                                 |
+| gardener_extension_networking_cilium_vector_overwrite_image_tag | | Allows overriding the image tag of the image vector images for the networking cilium extension  |
 
 ### Certificates
 

--- a/control-plane/roles/gardener/defaults/main/extensions.yaml
+++ b/control-plane/roles/gardener/defaults/main/extensions.yaml
@@ -1,6 +1,7 @@
 ---
 gardener_extension_networking_calico_enabled: true
 gardener_extension_networking_cilium_enabled: true
+gardener_extension_networking_cilium_vector_overwrite_image_tag: v1.12.1
 gardener_extension_os_metal_enabled: true
 gardener_extension_provider_gcp_enabled: true
 gardener_extension_provider_metal_enabled: true

--- a/control-plane/roles/gardener/defaults/main/extensions.yaml
+++ b/control-plane/roles/gardener/defaults/main/extensions.yaml
@@ -1,7 +1,7 @@
 ---
 gardener_extension_networking_calico_enabled: true
 gardener_extension_networking_cilium_enabled: true
-gardener_extension_networking_cilium_vector_overwrite_image_tag: v1.12.1
+gardener_extension_networking_cilium_vector_overwrite_image_tag:
 gardener_extension_os_metal_enabled: true
 gardener_extension_provider_gcp_enabled: true
 gardener_extension_provider_metal_enabled: true

--- a/control-plane/roles/gardener/defaults/main/extensions.yaml
+++ b/control-plane/roles/gardener/defaults/main/extensions.yaml
@@ -1,7 +1,6 @@
 ---
 gardener_extension_networking_calico_enabled: true
 gardener_extension_networking_cilium_enabled: true
-gardener_extension_networking_cilium_vector_overwrite_image_tag:
 gardener_extension_os_metal_enabled: true
 gardener_extension_provider_gcp_enabled: true
 gardener_extension_provider_metal_enabled: true
@@ -68,3 +67,9 @@ gardener_extension_provider_metal_image_pull_secret:
 gardener_cert_management_issuer_private_key: ""
 
 gardener_extension_dns_external_controller_registration_url:
+
+gardener_extension_networking_cilium_image_vector_overwrite: []
+  # - name: <image-name>
+  #   sourceRepository: /source/repository
+  #   repository: /repository
+  #   tag: <tag>

--- a/control-plane/roles/gardener/templates/networking-cilium/controller-deployment.yaml
+++ b/control-plane/roles/gardener/templates/networking-cilium/controller-deployment.yaml
@@ -14,7 +14,5 @@ providerConfig:
 {% if gardener_extension_networking_cilium_image_vector_overwrite %}
     imageVectorOverwrite: |
       images:
-{% for imageOverwrite in gardener_extension_networking_cilium_image_vector_overwrite %}
-          - "{{ imageOverwrite }}"
-{% endfor %}
+        {{ gardener_extension_networking_cilium_image_vector_overwrite | to_nice_yaml(indent=2) | indent(width=8, first=false) }}
 {% endif %}

--- a/control-plane/roles/gardener/templates/networking-cilium/controller-deployment.yaml
+++ b/control-plane/roles/gardener/templates/networking-cilium/controller-deployment.yaml
@@ -11,21 +11,10 @@ providerConfig:
       repository: "{{ gardener_networking_cilium_image_name }}"
       tag: "{{ gardener_networking_cilium_image_tag }}"
       pullPolicy: Always
+{% if gardener_extension_networking_cilium_image_vector_overwrite %}
     imageVectorOverwrite: |
       images:
-        - name: cilium-agent
-          sourceRepository: github.com/cilium/cilium
-          repository: quay.io/cilium/cilium
-          tag: "{{ gardener_extension_networking_cilium_vector_overwrite_image_tag }}"
-        - name: cilium-preflight
-          sourceRepository: github.com/cilium/cilium
-          repository: quay.io/cilium/cilium
-          tag: "{{ gardener_extension_networking_cilium_vector_overwrite_image_tag }}"
-        - name: cilium-operator
-          sourceRepository: github.com/cilium/cilium
-          repository: quay.io/cilium/operator
-          tag: "{{ gardener_extension_networking_cilium_vector_overwrite_image_tag }}"
-        - name: hubble-relay
-          sourceRepository: github.com/cilium/hubble-ui
-          repository: quay.io/cilium/hubble-relay
-          tag: "{{ gardener_extension_networking_cilium_vector_overwrite_image_tag }}"
+{% for imageOverwrite in gardener_extension_networking_cilium_image_vector_overwrite %}
+          - "{{ imageOverwrite }}"
+{% endfor %}
+{% endif %}

--- a/control-plane/roles/gardener/templates/networking-cilium/controller-deployment.yaml
+++ b/control-plane/roles/gardener/templates/networking-cilium/controller-deployment.yaml
@@ -16,16 +16,16 @@ providerConfig:
         - name: cilium-agent
           sourceRepository: github.com/cilium/cilium
           repository: quay.io/cilium/cilium
-          tag: v1.12.1
+          tag: "{{ gardener_extension_networking_cilium_vector_overwrite_image_tag }}"
         - name: cilium-preflight
           sourceRepository: github.com/cilium/cilium
           repository: quay.io/cilium/cilium
-          tag: v1.12.1
+          tag: "{{ gardener_extension_networking_cilium_vector_overwrite_image_tag }}"
         - name: cilium-operator
           sourceRepository: github.com/cilium/cilium
           repository: quay.io/cilium/operator
-          tag: v1.12.1
+          tag: "{{ gardener_extension_networking_cilium_vector_overwrite_image_tag }}"
         - name: hubble-relay
           sourceRepository: github.com/cilium/hubble-ui
           repository: quay.io/cilium/hubble-relay
-          tag: v1.12.1
+          tag: "{{ gardener_extension_networking_cilium_vector_overwrite_image_tag }}"


### PR DESCRIPTION
Alternative suggestions for the variable name are welcome.

## Breaking Change

```BREAKING_CHANGE
The static Cilium version image vector overwrite was removed. The extension now gets deployed by the image vector shipped with the networking extension.
```