### PR TITLE
Implement new SAG configuration for SONIC 202211

### DIFF
--- a/partition/roles/sonic/README.md
+++ b/partition/roles/sonic/README.md
@@ -45,6 +45,7 @@ It depends on the `switch_facts` module from `ansible-common`, so make sure modu
 | sonic_vlans.untagged_ports                                 |           | Array of untagged ports to bind to this VLAN.                                                                        |
 | sonic_vlans.tagged_ports                                   |           | Array of tagged ports to bind to this VLAN.                                                                          |
 | sonic_vlans.vrf                                            |           | The VRF to bind the VLANs SVI to.                                                                                    |
+| sonic_vlans.sag                                            |           | Whether to enable Static Anycast Gateway for this VLAN. Defaults to false in SONIC.                                  |
 | sonic_vteps                                                |           | VTEPs to configure. If defined FRR will automatically advertise all VNIs.                                            |
 | sonic_vteps.comment                                        |           | Description for the VTEP.                                                                                            |
 | sonic_vteps.vlan                                           |           | The local VLAN interface.                                                                                            |
@@ -82,9 +83,6 @@ It depends on the `switch_facts` module from `ansible-common`, so make sure modu
 | sonic_portchannels.members                                 |           | The list of the interfaces taking part in the portchannel.                                                           |
 | sonic_sag                                                  |           | Configuration for SAG (Static Anycast Gateway)                                                                       |
 | sonic_sag.mac                                              |           | The virtual MAC used for the SAG address                                                                             |
-| sonic_sag.vlans                                            |           | A list of VLANs that use SAG                                                                                         |
-| sonic_sag.vlans.id                                         |           | The VLAN ID of this VLAN                                                                                             |
-| sonic_sag.vlans.ip                                         |           | The SAG IP of this VLAN                                                                                              |
 | sonic_ssh_sourceranges                                     |           | The source ranges from which the switch should be reachable over SSH on its prod (non-management) addresses          |
 | sonic_extended_cacl.ipv4                                   |           | Iptables ipv4 rules that should be added as extended Control Plane ACLs (Edgecore Sonic specific feature)            |
 | sonic_extended_cacl.ipv6                                   |           | Iptables ipv6 rules that should be added as extended Control Plane ACLs (Edgecore Sonic specific feature)            |

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -123,8 +123,8 @@ PORTCHANNEL:
 {% for po in sonic_portchannels %}
   PortChannel{{ po.number }}:
     admin_status: "up"
-{% if po.fallback is defined %}
-    fallback: "{{ po.fallback|bool }}"
+{% if po.fallback is defined and po.fallback %}
+    fallback: "true"
 {% endif %}
     fast_rate: "false"
     lacp_key: "auto"
@@ -161,8 +161,8 @@ VLAN_INTERFACE:
   {% for vlan in sonic_vlans %}
   {% if vlan.vrf is defined %}
   Vlan{{ vlan.id }}:
-  {% if vlan.sag is defined %}
-    static_anycast_gateway: "{{ vlan.sag|bool }}"
+  {% if vlan.sag is defined and vlan.sag %}
+    static_anycast_gateway: "true"
   {% endif %}
     vrf_name: "{{ vlan.vrf }}"
   {% else %}

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -140,21 +140,11 @@ PORTCHANNEL_MEMBER:
 {% endfor %}
 {% endfor %}
 {% endif %}
-{% if sonic_sag is defined and sonic_sag|length > 0 %}
-{% if sonic_sag.vlans is defined and sonic_sag.vlans|length > 0 %}
+{% if sonic_sag.mac is defined %}
 
 SAG:
-{% for vlan in sonic_sag.vlans %}
-  "Vlan{{ vlan.id }}|IPv4":
-    gwip:
-    - "{{ vlan.ip }}"
-{% endfor %}
-{% endif %}
-
-SAG_GLOBAL:
-  IP:
-    IPv4: "enable"
-    gwmac: "{{ sonic_sag.mac }}"
+  GLOBAL:
+    gateway_mac: "{{ sonic_sag.mac }}"
 {% endif %}
 {% if sonic_vlans is defined and sonic_vlans|length > 0 %}
 
@@ -171,13 +161,9 @@ VLAN_INTERFACE:
   {% for vlan in sonic_vlans %}
   {% if vlan.vrf is defined %}
   Vlan{{ vlan.id }}:
-    {% if sonic_sag is defined and sonic_sag.vlans is defined %}
-    {% for sag_vlan in sonic_sag.vlans %}
-    {% if vlan.id == sag_vlan.id %}
-    "grat_arp_force_override": "enabled"
-    {% endif %}
-    {% endfor %}
-    {% endif %}
+  {% if vlan.sag is defined %}
+    static_anycast_gateway: "{{ vlan.sag|bool }}"
+  {% endif %}
     vrf_name: "{{ vlan.vrf }}"
   {% else %}
   Vlan{{ vlan.id }}: {}

--- a/partition/roles/sonic/test/data/l2_leaf/input.yaml
+++ b/partition/roles/sonic/test/data/l2_leaf/input.yaml
@@ -133,6 +133,7 @@ sonic_vlans:
   - PortChannel01
 - id: 1001
   vrf: Vrf46
+  sag: "true"
   tagged_ports:
   - PortChannel01
   untagged_ports:
@@ -201,9 +202,6 @@ sonic_portchannels:
 
 sonic_sag:
   mac: 00:11:22:33:44:66
-  vlans:
-  - id: 1001
-    ip: 10.3.2.1/27
 
 sonic_frr_l2vpn_evpn: true
 sonic_frr_route_map:

--- a/partition/roles/sonic/test/data/l2_leaf/metal.yaml
+++ b/partition/roles/sonic/test/data/l2_leaf/metal.yaml
@@ -248,14 +248,8 @@ PORTCHANNEL_MEMBER:
   PortChannel23|Ethernet2:  {}
 
 SAG:
-  "Vlan1001|IPv4":
-    gwip:
-    - "10.3.2.1/27"
-
-SAG_GLOBAL:
-  IP:
-    IPv4: "enable"
-    gwmac: "00:11:22:33:44:66"
+  GLOBAL:
+    gateway_mac: "00:11:22:33:44:66"
 
 VLAN:
   Vlan1000:
@@ -267,7 +261,7 @@ VLAN_INTERFACE:
   Vlan1000: {}
   Vlan1000|192.168.255.1/24: {}
   Vlan1001:
-    "grat_arp_force_override": "enabled"
+    static_anycast_gateway: "True"
     vrf_name: "Vrf46"
 
 VLAN_MEMBER:

--- a/partition/roles/sonic/test/data/l2_leaf/metal.yaml
+++ b/partition/roles/sonic/test/data/l2_leaf/metal.yaml
@@ -200,7 +200,7 @@ PORTCHANNEL:
     mtu: "9216"
   PortChannel11:
     admin_status: "up"
-    fallback: "True"
+    fallback: "true"
     fast_rate: "false"
     lacp_key: "auto"
     min_links: "1"
@@ -208,7 +208,7 @@ PORTCHANNEL:
     mtu: "9000"
   PortChannel12:
     admin_status: "up"
-    fallback: "True"
+    fallback: "true"
     fast_rate: "false"
     lacp_key: "auto"
     min_links: "1"
@@ -216,7 +216,7 @@ PORTCHANNEL:
     mtu: "9000"
   PortChannel21:
     admin_status: "up"
-    fallback: "True"
+    fallback: "true"
     fast_rate: "false"
     lacp_key: "auto"
     min_links: "1"
@@ -224,7 +224,6 @@ PORTCHANNEL:
     mtu: "9000"
   PortChannel22:
     admin_status: "up"
-    fallback: "False"
     fast_rate: "false"
     lacp_key: "auto"
     min_links: "1"
@@ -261,7 +260,7 @@ VLAN_INTERFACE:
   Vlan1000: {}
   Vlan1000|192.168.255.1/24: {}
   Vlan1001:
-    static_anycast_gateway: "True"
+    static_anycast_gateway: "true"
     vrf_name: "Vrf46"
 
 VLAN_MEMBER:


### PR DESCRIPTION
This is a breaking change for Static Anycast Gateway (SAG) configuration only, because the way SAG is configured changed from SONIC 202111 to 202211.
If SAG is not used, nothing changes.