### PR TITLE
Remove sonic ports defaults

### DIFF
--- a/partition/roles/metal-core/tasks/main.yaml
+++ b/partition/roles/metal-core/tasks/main.yaml
@@ -75,3 +75,5 @@
     port: 2112
     timeout: 300
     msg: "metal-core did not come up"
+  notify:
+  - restart bgp

--- a/partition/roles/metal-core/tasks/main.yaml
+++ b/partition/roles/metal-core/tasks/main.yaml
@@ -75,5 +75,3 @@
     port: 2112
     timeout: 300
     msg: "metal-core did not come up"
-  notify:
-  - restart bgp

--- a/partition/roles/sonic/README.md
+++ b/partition/roles/sonic/README.md
@@ -25,9 +25,6 @@ It depends on the `switch_facts` module from `ansible-common`, so make sure modu
 | sonic_ports.fec                                            |           | FEC used for the port.                                                                                               |
 | sonic_ports.vrf                                            |           | VRF where the port should bind to.                                                                                   |
 | sonic_ports.ips                                            |           | IPs to assign to the interface directly.                                                                             |
-| sonic_ports_default_mtu                                    |           | MTU default value for ports                                                                                          |
-| sonic_ports_default_fec                                    |           | FEC default value for ports                                                                                          |
-| sonic_ports_default_speed                                  |           | Speed default value for ports                                                                                        |
 | sonic_bgp_ports                                            |           | Ports for the underlay BGP sessions                                                                                  |
 | sonic_frr_render                                           |           | Render the frr config                                                                                                |
 | sonic_frr_debug_options                                    |           | Debugging options for FRR.                                                                                           |

--- a/partition/roles/sonic/defaults/main.yaml
+++ b/partition/roles/sonic/defaults/main.yaml
@@ -9,7 +9,6 @@ sonic_config_action: load
 ## Physical settings
 sonic_ports: []
 sonic_ports_dict: {}
-sonic_ports_default_fec: none
 
 ## Layer 2
 sonic_portchannels: []

--- a/partition/roles/sonic/tasks/main.yaml
+++ b/partition/roles/sonic/tasks/main.yaml
@@ -15,15 +15,6 @@
       - sonic_nameservers is defined
       - metal_stack_switch_os_is_sonic
 
-- name: Check mandatory variables on non-empty sonic_ports are set
-  assert:
-    fail_msg: "default port configuration is necessary on non-empty sonic_ports"
-    quiet: yes
-    that:
-      - sonic_ports_default_speed
-      - sonic_ports_default_mtu
-  when: sonic_ports
-
 - name: Check mandatory variables on non-empty sonic_portchannels are set
   assert:
     fail_msg: "default configuration is necessary on non-empty sonic_portchannels"

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -108,15 +108,15 @@ PORT:
     parent_port: {{ running_cfg.parent_port }}
     {% endif %}
     admin_status: up
-    {% set port = sonic_ports_dict[name] %}
-    {% if (port is defined and port.speed is defined) or running_cfg.speed is defined %}
-    speed: "{{ (port | default({})).speed | default(running_cfg.speed) }}"
+    {% set port = sonic_ports_dict[name] | default({}) %}
+    {% if port.speed is defined or running_cfg.speed is defined %}
+    speed: "{{ port.speed | default(running_cfg.speed) }}"
     {% endif %}
-    {% if (port is defined and port.mtu is defined) or running_cfg.mtu is defined %}
-    mtu: "{{ (port | default({})).mtu | default(running_cfg.mtu) }}"
+    {% if port.mtu is defined or running_cfg.mtu is defined %}
+    mtu: "{{ port.mtu | default(running_cfg.mtu) }}"
     {% endif %}
-    {% if (port is defined and port.fec is defined) or running_cfg.fec is defined %}
-    fec: "{{ (port | default({})).fec | default(running_cfg.fec) }}"
+    {% if port.fec is defined or running_cfg.fec is defined %}
+    fec: "{{ port.fec | default(running_cfg.fec) }}"
     {% endif %}
   {% endfor %}
 {% if sonic_portchannels %}

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -107,14 +107,16 @@ PORT:
     {% if 'parent_port' in running_cfg %}
     parent_port: {{ running_cfg.parent_port }}
     {% endif %}
-    {% if sonic_ports_dict[name] is defined %}
-    {% set port = sonic_ports_dict[name] %}
     admin_status: up
-    speed: "{{ port.speed|default(sonic_ports_default_speed) }}"
-    mtu: "{{ port.mtu|default(sonic_ports_default_mtu) }}"
-    fec: "{{ port.fec|default(sonic_ports_default_fec)|string|lower }}"
-    {% else %}
-    speed: "{{ running_cfg.speed }}"
+    {% set port = sonic_ports_dict[name] %}
+    {% if (port is defined and port.speed is defined) or running_cfg.speed is defined %}
+    speed: "{{ (port | default({})).speed | default(running_cfg.speed) }}"
+    {% endif %}
+    {% if (port is defined and port.mtu is defined) or running_cfg.mtu is defined %}
+    mtu: "{{ (port | default({})).mtu | default(running_cfg.mtu) }}"
+    {% endif %}
+    {% if (port is defined and port.fec is defined) or running_cfg.fec is defined %}
+    fec: "{{ (port | default({})).fec | default(running_cfg.fec) }}"
     {% endif %}
   {% endfor %}
 {% if sonic_portchannels %}

--- a/partition/roles/sonic/test/data/exit/input.yaml
+++ b/partition/roles/sonic/test/data/exit/input.yaml
@@ -6,8 +6,6 @@ sonic_loopback_address: 10.0.0.1
 sonic_breakouts:
   Ethernet0: "4x10G"
 
-sonic_ports_default_mtu: 9216
-sonic_ports_default_speed: 100000
 sonic_ports_dict:
   Ethernet0:
     speed: 10000

--- a/partition/roles/sonic/test/data/exit/metal.yaml
+++ b/partition/roles/sonic/test/data/exit/metal.yaml
@@ -61,13 +61,13 @@ PORT:
     admin_status: up
     speed: "10000"
     mtu: "1500"
-    fec: "none"
   Ethernet1:
     alias: Eth1/2(Port1)
     autoneg: "off"
     index: "1"
     lanes: "2"
     parent_port: Ethernet0
+    admin_status: up
     speed: "10000"
   Ethernet2:
     alias: Eth1/3(Port1)
@@ -75,6 +75,7 @@ PORT:
     index: "1"
     lanes: "3"
     parent_port: Ethernet0
+    admin_status: up
     speed: "10000"
   Ethernet3:
     alias: Eth1/4(Port1)
@@ -82,6 +83,7 @@ PORT:
     index: "1"
     lanes: "4"
     parent_port: Ethernet0
+    admin_status: up
     speed: "10000"
   Ethernet112:
     alias: Eth29(Port29)
@@ -91,8 +93,6 @@ PORT:
     parent_port: Ethernet112
     admin_status: up
     speed: "100000"
-    mtu: "9216"
-    fec: "none"
   Ethernet116:
     alias: Eth30(Port30)
     autoneg: "off"
@@ -101,8 +101,6 @@ PORT:
     parent_port: Ethernet116
     admin_status: up
     speed: "100000"
-    mtu: "9216"
-    fec: "none"
 
 VLAN:
   Vlan4000:

--- a/partition/roles/sonic/test/data/l2_leaf/input.yaml
+++ b/partition/roles/sonic/test/data/l2_leaf/input.yaml
@@ -7,8 +7,6 @@ sonic_breakouts:
   Ethernet0: "4x25G"
   Ethernet4: "4x25G"
 
-sonic_ports_default_mtu: 9000
-sonic_ports_default_speed: 25000
 sonic_ports_dict:
   Ethernet0:
   Ethernet1:

--- a/partition/roles/sonic/test/data/l2_leaf/metal.yaml
+++ b/partition/roles/sonic/test/data/l2_leaf/metal.yaml
@@ -86,8 +86,6 @@ PORT:
     parent_port: Ethernet0
     admin_status: up
     speed: "25000"
-    mtu: "9000"
-    fec: "none"
   Ethernet1:
     alias: Eth1/2(Port1)
     autoneg: "off"
@@ -96,8 +94,6 @@ PORT:
     parent_port: Ethernet0
     admin_status: up
     speed: "25000"
-    mtu: "9000"
-    fec: "none"
   Ethernet2:
     alias: Eth1/3(Port1)
     autoneg: "off"
@@ -106,14 +102,13 @@ PORT:
     parent_port: Ethernet0
     admin_status: up
     speed: "25000"
-    mtu: "9000"
-    fec: "none"
   Ethernet3:
     alias: Eth1/4(Port1)
     autoneg: "off"
     index: "1"
     lanes: "4"
     parent_port: Ethernet0
+    admin_status: up
     speed: "25000"
   Ethernet4:
     alias: Eth2/1(Port2)
@@ -123,8 +118,6 @@ PORT:
     parent_port: Ethernet4
     admin_status: up
     speed: "25000"
-    mtu: "9000"
-    fec: "none"
   Ethernet5:
     alias: Eth2/2(Port2)
     autoneg: "off"
@@ -133,14 +126,13 @@ PORT:
     parent_port: Ethernet4
     admin_status: up
     speed: "25000"
-    mtu: "9000"
-    fec: "none"
   Ethernet6:
     alias: Eth2/3(Port2)
     autoneg: "off"
     index: "2"
     lanes: "3"
     parent_port: Ethernet4
+    admin_status: up
     speed: "25000"
   Ethernet7:
     alias: Eth2/4(Port2)
@@ -148,6 +140,7 @@ PORT:
     index: "2"
     lanes: "4"
     parent_port: Ethernet4
+    admin_status: up
     speed: "25000"
   Ethernet112:
     alias: Eth29(Port29)
@@ -158,7 +151,6 @@ PORT:
     admin_status: up
     speed: "100000"
     mtu: "9216"
-    fec: "none"
   Ethernet116:
     alias: Eth30(Port30)
     autoneg: "off"
@@ -168,7 +160,6 @@ PORT:
     admin_status: up
     speed: "100000"
     mtu: "9216"
-    fec: "none"
   Ethernet120:
     alias: Eth31(Port31)
     autoneg: "off"
@@ -178,7 +169,6 @@ PORT:
     admin_status: up
     speed: "100000"
     mtu: "9216"
-    fec: "none"
   Ethernet124:
     alias: Eth32(Port32)
     autoneg: "off"
@@ -188,7 +178,6 @@ PORT:
     admin_status: up
     speed: "100000"
     mtu: "9216"
-    fec: "none"
 
 PORTCHANNEL:
   PortChannel01:

--- a/partition/roles/sonic/test/data/mgmtleaf/input.yaml
+++ b/partition/roles/sonic/test/data/mgmtleaf/input.yaml
@@ -10,8 +10,6 @@ sonic_ntpservers: ['1.2.3.4']
 sonic_breakouts:
   Ethernet0: "4x25G"
 
-sonic_ports_default_mtu: 9000
-sonic_ports_default_speed: 1000
 sonic_ports_dict:
   Ethernet0:
   Ethernet1:

--- a/partition/roles/sonic/test/data/mgmtleaf/metal.yaml
+++ b/partition/roles/sonic/test/data/mgmtleaf/metal.yaml
@@ -63,9 +63,7 @@ PORT:
     lanes: "1"
     parent_port: Ethernet0
     admin_status: up
-    speed: "1000"
-    mtu: "9000"
-    fec: "none"
+    speed: "25000"
   Ethernet1:
     alias: Eth1/2(Port1)
     autoneg: "off"
@@ -73,9 +71,7 @@ PORT:
     lanes: "2"
     parent_port: Ethernet0
     admin_status: up
-    speed: "1000"
-    mtu: "9000"
-    fec: "none"
+    speed: "25000"
   Ethernet2:
     alias: Eth1/3(Port1)
     autoneg: "off"
@@ -83,9 +79,7 @@ PORT:
     lanes: "3"
     parent_port: Ethernet0
     admin_status: up
-    speed: "1000"
-    mtu: "9000"
-    fec: "none"
+    speed: "25000"
   Ethernet3:
     alias: Eth1/4(Port1)
     autoneg: "off"
@@ -93,15 +87,14 @@ PORT:
     lanes: "4"
     parent_port: Ethernet0
     admin_status: up
-    speed: "1000"
-    mtu: "9000"
-    fec: "none"
+    speed: "25000"
   Ethernet4:
     alias: Eth2(Port2)
     autoneg: "off"
     index: "2"
     lanes: "5,6,7,8"
     parent_port: Ethernet4
+    admin_status: up
     speed: "100000"
   Ethernet120:
     alias: Eth31(Port31)
@@ -121,8 +114,6 @@ PORT:
     parent_port: Ethernet124
     admin_status: up
     speed: "100000"
-    mtu: "9000"
-    fec: "none"
 
 VLAN:
   Vlan1:

--- a/partition/roles/sonic/test/data/sonic-vs/input.yaml
+++ b/partition/roles/sonic/test/data/sonic-vs/input.yaml
@@ -10,8 +10,6 @@ sonic_mgmt_vrf: false
 sonic_docker_routing_config_mode: split-unified
 sonic_frr_mgmt_framework_config: false
 
-sonic_ports_default_mtu: 9000
-sonic_ports_default_speed: 40000
 sonic_ports_dict:
   Ethernet0:
 

--- a/partition/roles/sonic/test/data/sonic-vs/metal.yaml
+++ b/partition/roles/sonic/test/data/sonic-vs/metal.yaml
@@ -49,13 +49,12 @@ PORT:
     lanes: "25,26,27,28"
     admin_status: up
     speed: "40000"
-    mtu: "9000"
-    fec: "none"
   Ethernet4:
     alias: fortyGigE0/4
     autoneg: "off"
     index: "1"
     lanes: "29,30,31,32"
+    admin_status: up
     speed: "40000"
 
 VLAN:

--- a/partition/roles/sonic/test/data/spine/input.yaml
+++ b/partition/roles/sonic/test/data/spine/input.yaml
@@ -8,8 +8,6 @@ sonic_bgp_ports:
 - Ethernet120
 - Ethernet124
 
-sonic_ports_default_mtu: 9216
-sonic_ports_default_speed: 100000
 sonic_ports_dict:
   Ethernet120:
   Ethernet124:

--- a/partition/roles/sonic/test/data/spine/metal.yaml
+++ b/partition/roles/sonic/test/data/spine/metal.yaml
@@ -55,8 +55,6 @@ PORT:
     parent_port: Ethernet120
     admin_status: up
     speed: "100000"
-    mtu: "9216"
-    fec: "none"
   Ethernet124:
     alias: Eth32(Port32)
     autoneg: "off"
@@ -65,8 +63,6 @@ PORT:
     parent_port: Ethernet124
     admin_status: up
     speed: "100000"
-    mtu: "9216"
-    fec: "none"
 
 LLDP:
   Global:


### PR DESCRIPTION
## Additional Description

Currently, if the `sonic_ports` variable is defined the sonic role will require default values for fec, mtu and speed to be set. A more reasonable behavior, in my opinion, is to leave all settings of the running configuration in place, if no value was provided.

## Breaking Change

```BREAKING_CHANGE
`sonic_ports_default_mtu`, `sonic_ports_default_fec` and `sonic_ports_default_speed` are not used anymore. Each port requires and individual configuration.
```