### PR TITLE
Use running configuration for sonic ports

### DIFF
--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -107,13 +107,14 @@ PORT:
     {% if 'parent_port' in running_cfg %}
     parent_port: {{ running_cfg.parent_port }}
     {% endif %}
-    admin_status: up
     {% if sonic_ports_dict[name] is defined %}
     {% set port = sonic_ports_dict[name] %}
+    admin_status: {{ port.admin_status|default('up') }}
     speed: "{{ port.speed|default(sonic_ports_default_speed) }}"
     mtu: "{{ port.mtu|default(sonic_ports_default_mtu) }}"
-    fec: "{{ port.fec|default(sonic_ports_default_fec)|string|lower }}"
+    fec: {{ port.fec|default(sonic_ports_default_fec)|string|lower }}
     {% else %}
+    admin_status: up
     {% if running_cfg.speed is defined %}
     speed: "{{ running_cfg.speed }}"
     {% endif %}
@@ -121,7 +122,7 @@ PORT:
     mtu: "{{ running_cfg.mtu }}"
     {% endif %}
     {% if running_cfg.fec is defined %}
-    fec: "{{ running_cfg.fec }}"
+    fec: {{ running_cfg.fec }}
     {% endif %}
     {% endif %}
   {% endfor %}

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -107,14 +107,22 @@ PORT:
     {% if 'parent_port' in running_cfg %}
     parent_port: {{ running_cfg.parent_port }}
     {% endif %}
+    admin_status: up
     {% if sonic_ports_dict[name] is defined %}
     {% set port = sonic_ports_dict[name] %}
-    admin_status: up
     speed: "{{ port.speed|default(sonic_ports_default_speed) }}"
     mtu: "{{ port.mtu|default(sonic_ports_default_mtu) }}"
     fec: "{{ port.fec|default(sonic_ports_default_fec)|string|lower }}"
     {% else %}
+    {% if running_cfg.speed is defined %}
     speed: "{{ running_cfg.speed }}"
+    {% endif %}
+    {% if running_cfg.mtu is defined %}
+    mtu: "{{ running_cfg.mtu }}"
+    {% endif %}
+    {% if running_cfg.fec is defined %}
+    fec: "{{ running_cfg.fec }}"
+    {% endif %}
     {% endif %}
   {% endfor %}
 {% if sonic_portchannels %}

--- a/partition/roles/sonic/test/data/exit/metal.yaml
+++ b/partition/roles/sonic/test/data/exit/metal.yaml
@@ -61,7 +61,7 @@ PORT:
     admin_status: up
     speed: "10000"
     mtu: "1500"
-    fec: "none"
+    fec: none
   Ethernet1:
     alias: Eth1/2(Port1)
     autoneg: "off"
@@ -95,7 +95,7 @@ PORT:
     admin_status: up
     speed: "100000"
     mtu: "9216"
-    fec: "none"
+    fec: none
   Ethernet116:
     alias: Eth30(Port30)
     autoneg: "off"
@@ -105,7 +105,7 @@ PORT:
     admin_status: up
     speed: "100000"
     mtu: "9216"
-    fec: "none"
+    fec: none
 
 VLAN:
   Vlan4000:

--- a/partition/roles/sonic/test/data/exit/metal.yaml
+++ b/partition/roles/sonic/test/data/exit/metal.yaml
@@ -68,6 +68,7 @@ PORT:
     index: "1"
     lanes: "2"
     parent_port: Ethernet0
+    admin_status: up
     speed: "10000"
   Ethernet2:
     alias: Eth1/3(Port1)
@@ -75,6 +76,7 @@ PORT:
     index: "1"
     lanes: "3"
     parent_port: Ethernet0
+    admin_status: up
     speed: "10000"
   Ethernet3:
     alias: Eth1/4(Port1)
@@ -82,6 +84,7 @@ PORT:
     index: "1"
     lanes: "4"
     parent_port: Ethernet0
+    admin_status: up
     speed: "10000"
   Ethernet112:
     alias: Eth29(Port29)

--- a/partition/roles/sonic/test/data/l2_leaf/input.yaml
+++ b/partition/roles/sonic/test/data/l2_leaf/input.yaml
@@ -72,7 +72,9 @@ sonic_running_cfg_ports:
     index: "1"
     lanes: "4"
     parent_port: Ethernet0
-    speed: "25000"
+    speed: "10000"
+    fec: "rs"
+    mtu: "9100"
   Ethernet4:
     alias: Eth2/1(Port2)
     index: "2"

--- a/partition/roles/sonic/test/data/l2_leaf/input.yaml
+++ b/partition/roles/sonic/test/data/l2_leaf/input.yaml
@@ -73,7 +73,7 @@ sonic_running_cfg_ports:
     lanes: "4"
     parent_port: Ethernet0
     speed: "10000"
-    fec: "rs"
+    fec: rs
     mtu: "9100"
   Ethernet4:
     alias: Eth2/1(Port2)

--- a/partition/roles/sonic/test/data/l2_leaf/metal.yaml
+++ b/partition/roles/sonic/test/data/l2_leaf/metal.yaml
@@ -114,7 +114,10 @@ PORT:
     index: "1"
     lanes: "4"
     parent_port: Ethernet0
-    speed: "25000"
+    admin_status: up
+    speed: "10000"
+    mtu: "9100"
+    fec: "rs"
   Ethernet4:
     alias: Eth2/1(Port2)
     autoneg: "off"
@@ -141,6 +144,7 @@ PORT:
     index: "2"
     lanes: "3"
     parent_port: Ethernet4
+    admin_status: up
     speed: "25000"
   Ethernet7:
     alias: Eth2/4(Port2)
@@ -148,6 +152,7 @@ PORT:
     index: "2"
     lanes: "4"
     parent_port: Ethernet4
+    admin_status: up
     speed: "25000"
   Ethernet112:
     alias: Eth29(Port29)

--- a/partition/roles/sonic/test/data/l2_leaf/metal.yaml
+++ b/partition/roles/sonic/test/data/l2_leaf/metal.yaml
@@ -87,7 +87,7 @@ PORT:
     admin_status: up
     speed: "25000"
     mtu: "9000"
-    fec: "none"
+    fec: none
   Ethernet1:
     alias: Eth1/2(Port1)
     autoneg: "off"
@@ -97,7 +97,7 @@ PORT:
     admin_status: up
     speed: "25000"
     mtu: "9000"
-    fec: "none"
+    fec: none
   Ethernet2:
     alias: Eth1/3(Port1)
     autoneg: "off"
@@ -107,7 +107,7 @@ PORT:
     admin_status: up
     speed: "25000"
     mtu: "9000"
-    fec: "none"
+    fec: none
   Ethernet3:
     alias: Eth1/4(Port1)
     autoneg: "off"
@@ -117,7 +117,7 @@ PORT:
     admin_status: up
     speed: "10000"
     mtu: "9100"
-    fec: "rs"
+    fec: rs
   Ethernet4:
     alias: Eth2/1(Port2)
     autoneg: "off"
@@ -127,7 +127,7 @@ PORT:
     admin_status: up
     speed: "25000"
     mtu: "9000"
-    fec: "none"
+    fec: none
   Ethernet5:
     alias: Eth2/2(Port2)
     autoneg: "off"
@@ -137,7 +137,7 @@ PORT:
     admin_status: up
     speed: "25000"
     mtu: "9000"
-    fec: "none"
+    fec: none
   Ethernet6:
     alias: Eth2/3(Port2)
     autoneg: "off"
@@ -163,7 +163,7 @@ PORT:
     admin_status: up
     speed: "100000"
     mtu: "9216"
-    fec: "none"
+    fec: none
   Ethernet116:
     alias: Eth30(Port30)
     autoneg: "off"
@@ -173,7 +173,7 @@ PORT:
     admin_status: up
     speed: "100000"
     mtu: "9216"
-    fec: "none"
+    fec: none
   Ethernet120:
     alias: Eth31(Port31)
     autoneg: "off"
@@ -183,7 +183,7 @@ PORT:
     admin_status: up
     speed: "100000"
     mtu: "9216"
-    fec: "none"
+    fec: none
   Ethernet124:
     alias: Eth32(Port32)
     autoneg: "off"
@@ -193,7 +193,7 @@ PORT:
     admin_status: up
     speed: "100000"
     mtu: "9216"
-    fec: "none"
+    fec: none
 
 PORTCHANNEL:
   PortChannel01:

--- a/partition/roles/sonic/test/data/mgmtleaf/metal.yaml
+++ b/partition/roles/sonic/test/data/mgmtleaf/metal.yaml
@@ -65,7 +65,7 @@ PORT:
     admin_status: up
     speed: "1000"
     mtu: "9000"
-    fec: "none"
+    fec: none
   Ethernet1:
     alias: Eth1/2(Port1)
     autoneg: "off"
@@ -75,7 +75,7 @@ PORT:
     admin_status: up
     speed: "1000"
     mtu: "9000"
-    fec: "none"
+    fec: none
   Ethernet2:
     alias: Eth1/3(Port1)
     autoneg: "off"
@@ -85,7 +85,7 @@ PORT:
     admin_status: up
     speed: "1000"
     mtu: "9000"
-    fec: "none"
+    fec: none
   Ethernet3:
     alias: Eth1/4(Port1)
     autoneg: "off"
@@ -95,7 +95,7 @@ PORT:
     admin_status: up
     speed: "1000"
     mtu: "9000"
-    fec: "none"
+    fec: none
   Ethernet4:
     alias: Eth2(Port2)
     autoneg: "off"
@@ -113,7 +113,7 @@ PORT:
     admin_status: up
     speed: "100000"
     mtu: "9216"
-    fec: "rs"
+    fec: rs
   Ethernet124:
     alias: Eth32(Port32)
     autoneg: "off"
@@ -123,7 +123,7 @@ PORT:
     admin_status: up
     speed: "100000"
     mtu: "9000"
-    fec: "none"
+    fec: none
 
 VLAN:
   Vlan1:

--- a/partition/roles/sonic/test/data/mgmtleaf/metal.yaml
+++ b/partition/roles/sonic/test/data/mgmtleaf/metal.yaml
@@ -102,6 +102,7 @@ PORT:
     index: "2"
     lanes: "5,6,7,8"
     parent_port: Ethernet4
+    admin_status: up
     speed: "100000"
   Ethernet120:
     alias: Eth31(Port31)

--- a/partition/roles/sonic/test/data/sonic-vs/metal.yaml
+++ b/partition/roles/sonic/test/data/sonic-vs/metal.yaml
@@ -50,7 +50,7 @@ PORT:
     admin_status: up
     speed: "40000"
     mtu: "9000"
-    fec: "none"
+    fec: none
   Ethernet4:
     alias: fortyGigE0/4
     autoneg: "off"

--- a/partition/roles/sonic/test/data/sonic-vs/metal.yaml
+++ b/partition/roles/sonic/test/data/sonic-vs/metal.yaml
@@ -56,6 +56,7 @@ PORT:
     autoneg: "off"
     index: "1"
     lanes: "29,30,31,32"
+    admin_status: up
     speed: "40000"
 
 VLAN:

--- a/partition/roles/sonic/test/data/spine/metal.yaml
+++ b/partition/roles/sonic/test/data/spine/metal.yaml
@@ -56,7 +56,7 @@ PORT:
     admin_status: up
     speed: "100000"
     mtu: "9216"
-    fec: "none"
+    fec: none
   Ethernet124:
     alias: Eth32(Port32)
     autoneg: "off"
@@ -66,7 +66,7 @@ PORT:
     admin_status: up
     speed: "100000"
     mtu: "9216"
-    fec: "none"
+    fec: none
 
 LLDP:
   Global:


### PR DESCRIPTION
## References

Replaces https://github.com/metal-stack/metal-roles/pull/323

## Additional Description

This is a compromise that doesn't introduce any breaking changes. Default mtu, speed and fec for SONiC ports can still be used. Additionally, if the running configuration holds values for mtu, speed and fec these values will be considered for the new config. The reasoning behind this PR is that all values that are not explicitly defined should remain as they are, while the current template will remove mtu and fec from ports, that are not part of the `sonic_ports` dictionary.