### PR TITLE
Restart bgp after initial metal-core deployment

### DIFF
--- a/partition/roles/metal-core/tasks/main.yaml
+++ b/partition/roles/metal-core/tasks/main.yaml
@@ -75,3 +75,14 @@
     port: 2112
     timeout: 300
     msg: "metal-core did not come up"
+
+- name: check if bgp session is up
+  ansible.builtin.command: vtysh -c 'show bgp summary'
+  register: bgp_summary
+  changed_when: false
+
+- name: restart bgp if necessary
+  systemd:
+    name: bgp
+    state: restarted
+  when: "'BGP instance not found' in bgp_summary.stdout"


### PR DESCRIPTION
If metal-core is deployed for the first time on a switch, the bgp session does not come up before bgp is restarted. Currently this is done manually. This PR is an attempt to automate this process. It needs some more testing to see if it really solves the problem.