### PR TITLE
Allow configuration of DNS nameservers used for checking DNS propagation. 

### DIFF
--- a/control-plane/roles/gardener/README.md
+++ b/control-plane/roles/gardener/README.md
@@ -116,6 +116,7 @@ This includes the metal-stack extension provider called [gardener-extension-prov
 | gardener_extension_networking_cilium_image_vector_overwrite  |           | Allows overriding the image vector for the networking cilium extension                                                                      |
 | gardener_cert_management_issuer_email                        |           | The issuer email used by the cert-management extension                                                                                      |
 | gardener_cert_management_issuer_server                       |           | The issuer server used by the cert-management extension                                                                                     |
+| gardener_cert_management_precheck_nameservers                |           | To provide special set of nameservers to be used for prechecking DNSChallenges for an issuer                                                |
 
 ### Certificates
 

--- a/control-plane/roles/gardener/defaults/main/extensions.yaml
+++ b/control-plane/roles/gardener/defaults/main/extensions.yaml
@@ -68,6 +68,7 @@ gardener_extension_provider_metal_image_pull_secret:
 gardener_cert_management_issuer_private_key: ""
 gardener_cert_management_issuer_server: https://acme-v02.api.letsencrypt.org/directory
 gardener_cert_management_issuer_email:
+gardener_cert_management_precheck_nameservers: []
 
 gardener_extension_dns_external_controller_registration_url:
 

--- a/control-plane/roles/gardener/templates/shoot-cert-service/controller-deployment.yaml
+++ b/control-plane/roles/gardener/templates/shoot-cert-service/controller-deployment.yaml
@@ -19,3 +19,6 @@ providerConfig:
           server: "{{ gardener_cert_management_issuer_server }}"
           privateKey: |
             {{ gardener_cert_management_issuer_private_key | indent(width=12, first=false) }}
+{% if gardener_cert_management_precheck_nameservers %}
+      precheckNameservers: "{{ gardener_cert_management_precheck_nameservers | join(',') }}"
+{% endif %}


### PR DESCRIPTION
## Description

Used in on-premise setup to speed up the DNS challenge when the platform has only write access to the zone that is delegated to a different nameserver.