### PR TITLE
Remove dns-controller-manager subcomponent from release vector

### DIFF
--- a/control-plane/roles/gardener/README.md
+++ b/control-plane/roles/gardener/README.md
@@ -118,6 +118,7 @@ This includes the metal-stack extension provider called [gardener-extension-prov
 | gardener_cert_management_issuer_server                       |           | The issuer server used by the cert-management extension                                                                                     |
 | gardener_cert_management_precheck_nameservers                |           | To provide special set of nameservers to be used for prechecking DNSChallenges for an issuer                                                |
 | gardener_cert_management_shoot_issuers_enabled               |           | If enabled, allows to specify issuers in the shoot clusters                                                                                 |
+| gardener_shoot_dns_service_image_vector_overwrite            |           | Allows overriding the image vector for the shoot-dns-service extension                                                                      |
 
 ### Certificates
 

--- a/control-plane/roles/gardener/README.md
+++ b/control-plane/roles/gardener/README.md
@@ -119,6 +119,8 @@ This includes the metal-stack extension provider called [gardener-extension-prov
 | gardener_cert_management_precheck_nameservers                |           | To provide special set of nameservers to be used for prechecking DNSChallenges for an issuer                                                |
 | gardener_cert_management_shoot_issuers_enabled               |           | If enabled, allows to specify issuers in the shoot clusters                                                                                 |
 | gardener_shoot_dns_service_image_vector_overwrite            |           | Allows overriding the image vector for the shoot-dns-service extension                                                                      |
+| gardener_shoot_dns_service_dns_controller_manager_image_name |           | Setting an explicit image name for the dns-controller-manager                                                                               |
+| gardener_shoot_dns_service_dns_controller_manager_image_tag  |           | Setting an explicit image tag for the dns-controller-manager                                                                                |
 
 ### Certificates
 

--- a/control-plane/roles/gardener/defaults/main/extensions.yaml
+++ b/control-plane/roles/gardener/defaults/main/extensions.yaml
@@ -84,3 +84,5 @@ gardener_shoot_dns_service_image_vector_overwrite: []
   #   sourceRepository: github.com/gardener/external-dns-management
   #   repository: europe-docker.pkg.dev/gardener-project/public/dns-controller-manager
   #   tag: "0.7.1"
+gardener_shoot_dns_service_dns_controller_manager_image_name:
+gardener_shoot_dns_service_dns_controller_manager_image_tag:

--- a/control-plane/roles/gardener/defaults/main/extensions.yaml
+++ b/control-plane/roles/gardener/defaults/main/extensions.yaml
@@ -78,3 +78,9 @@ gardener_extension_networking_cilium_image_vector_overwrite: []
   #   sourceRepository: /source/repository
   #   repository: /repository
   #   tag: <tag>
+
+gardener_shoot_dns_service_image_vector_overwrite: []
+  # - name: dns-controller-manager
+  #   sourceRepository: github.com/gardener/external-dns-management
+  #   repository: europe-docker.pkg.dev/gardener-project/public/dns-controller-manager
+  #   tag: "0.7.1"

--- a/control-plane/roles/gardener/templates/shoot-dns-service/controller-deployment.yaml
+++ b/control-plane/roles/gardener/templates/shoot-dns-service/controller-deployment.yaml
@@ -11,8 +11,8 @@ providerConfig:
       repository: "{{ gardener_shoot_dns_service_image_name }}"
       tag: "{{ gardener_shoot_dns_service_image_tag }}"
 {% if gardener_shoot_dns_service_image_vector_overwrite %}
-      imageVectorOverwrite:
-        images: "{{ gardener_shoot_dns_service_image_vector_overwrite | to_json }}"
+    imageVectorOverwrite:
+      images: "{{ gardener_shoot_dns_service_image_vector_overwrite | to_json }}"
 {% endif %}
     dnsProviderManagement:
       enabled: true

--- a/control-plane/roles/gardener/templates/shoot-dns-service/controller-deployment.yaml
+++ b/control-plane/roles/gardener/templates/shoot-dns-service/controller-deployment.yaml
@@ -11,7 +11,7 @@ providerConfig:
       repository: "{{ gardener_shoot_dns_service_image_name }}"
       tag: "{{ gardener_shoot_dns_service_image_tag }}"
 {% if gardener_shoot_dns_service_image_vector_overwrite %}
-    imageVectorOverwrite:
+    imageVectorOverwrite: |
       images: "{{ gardener_shoot_dns_service_image_vector_overwrite | to_json }}"
 {% endif %}
     dnsProviderManagement:

--- a/control-plane/roles/gardener/templates/shoot-dns-service/controller-deployment.yaml
+++ b/control-plane/roles/gardener/templates/shoot-dns-service/controller-deployment.yaml
@@ -12,9 +12,19 @@ providerConfig:
       tag: "{{ gardener_shoot_dns_service_image_tag }}"
 {% if gardener_shoot_dns_service_image_vector_overwrite %}
     imageVectorOverwrite: |
-      images: "{{ gardener_shoot_dns_service_image_vector_overwrite | to_json }}"
+      images:
+        {{ gardener_shoot_dns_service_image_vector_overwrite | to_nice_yaml(indent=2) | indent(width=8, first=false) }}
 {% endif %}
     dnsProviderManagement:
       enabled: true
     dnsControllerManager:
       deploy: true
+{% if gardener_shoot_dns_service_dns_controller_manager_image_name or gardener_shoot_dns_service_dns_controller_manager_image_tag %}
+      image:
+{% if gardener_shoot_dns_service_dns_controller_manager_image_tag %}
+        tag: "{{ gardener_shoot_dns_service_dns_controller_manager_image_tag }}"
+{% endif %}
+{% if gardener_shoot_dns_service_dns_controller_manager_image_name %}
+        repository: "{{ gardener_shoot_dns_service_dns_controller_manager_image_name }}"
+{% endif %}
+{% endif %}

--- a/control-plane/roles/gardener/templates/shoot-dns-service/controller-deployment.yaml
+++ b/control-plane/roles/gardener/templates/shoot-dns-service/controller-deployment.yaml
@@ -10,6 +10,10 @@ providerConfig:
     image:
       repository: "{{ gardener_shoot_dns_service_image_name }}"
       tag: "{{ gardener_shoot_dns_service_image_tag }}"
+{% if gardener_shoot_dns_service_image_vector_overwrite %}
+      imageVectorOverwrite:
+        images: "{{ gardener_shoot_dns_service_image_vector_overwrite | to_json }}"
+{% endif %}
     dnsProviderManagement:
       enabled: true
     dnsControllerManager:

--- a/control-plane/roles/gardener/templates/shoot-dns-service/controller-deployment.yaml
+++ b/control-plane/roles/gardener/templates/shoot-dns-service/controller-deployment.yaml
@@ -13,7 +13,4 @@ providerConfig:
     dnsProviderManagement:
       enabled: true
     dnsControllerManager:
-      image:
-        tag: "{{ gardener_dns_controller_manager_image_tag }}"
-        repository: "{{ gardener_dns_controller_manager_image_name }}"
       deploy: true

--- a/control-plane/roles/gardener/test/dns_extension_template_test.py
+++ b/control-plane/roles/gardener/test/dns_extension_template_test.py
@@ -1,0 +1,80 @@
+import unittest
+import sys
+import yaml
+
+from ansible.template import Templar
+from test import read_template_file
+from unittest.mock import patch, MagicMock
+
+class ShootDnsExtensionControllerDeploymentTemplate(unittest.TestCase):
+    @patch('urllib.request.urlopen')
+    def test_shoot_dns_extension_controller_deployment_template(self, mock_urlopen):
+        cm = MagicMock()
+        cm.getcode.return_value = 200
+        cm.read.return_value = '''
+---
+apiVersion: core.gardener.cloud/v1beta1
+kind: ControllerDeployment
+metadata:
+  name: extension-shoot-dns-service
+type: helm
+providerConfig:
+  chart: a-chart
+  values:
+    image:
+      tag: v1.48.0
+'''
+        mock_urlopen.return_value = cm
+
+        t = read_template_file("shoot-dns-service/controller-deployment.yaml")
+
+        templar = Templar(loader=None, variables={
+            "gardener_shoot_dns_service_image_tag": "v0.0.1",
+            "gardener_shoot_dns_service_repo_ref": "gardener/gardener-extension-shoot-dns-service/{{ gardener_shoot_dns_service_image_tag }}",
+            "gardener_shoot_dns_service_image_name": "extension-image",
+            "gardener_shoot_dns_service_image_tag": "extension-tag",
+            "gardener_shoot_dns_service_image_vector_overwrite": [
+                {
+                    "name": "dns-controller-manager",
+                    "sourceRepository": "github.com/gardener/external-dns-management",
+                    "repository": "europe-docker.pkg.dev/gardener-project/public/dns-controller-manager",
+                    "tag": "0.7.1",
+                },
+            ],
+            "gardener_shoot_dns_service_dns_controller_manager_image_name": "dns-controller-image",
+            "gardener_shoot_dns_service_dns_controller_manager_image_tag": "dns-controller-tag",
+        })
+
+
+        res = templar.template(t)
+
+        expected = '''
+---
+apiVersion: core.gardener.cloud/v1beta1
+kind: ControllerDeployment
+metadata:
+  name: extension-shoot-dns-service
+type: helm
+providerConfig:
+  chart: "a-chart"
+  values:
+    image:
+      repository: "extension-image"
+      tag: "extension-tag"
+    imageVectorOverwrite: |
+      images:
+        - name: dns-controller-manager
+          repository: europe-docker.pkg.dev/gardener-project/public/dns-controller-manager
+          sourceRepository: github.com/gardener/external-dns-management
+          tag: 0.7.1
+    dnsProviderManagement:
+      enabled: true
+    dnsControllerManager:
+      deploy: true
+      image:
+        tag: "dns-controller-tag"
+        repository: "dns-controller-image"
+'''
+
+        self.maxDiff = None
+        self.assertDictEqual(yaml.safe_load(expected), yaml.safe_load(res))

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -125,8 +125,6 @@ metal_stack_release:
     gardener_shoot_cert_service_image_name: "docker-images.third-party.gardener.shoot-cert-service.name"
     gardener_shoot_dns_service_image_tag: "docker-images.third-party.gardener.shoot-dns-service.tag"
     gardener_shoot_dns_service_image_name: "docker-images.third-party.gardener.shoot-dns-service.name"
-    gardener_dns_controller_manager_image_tag: "docker-images.third-party.gardener.dns-controller-manager.tag"
-    gardener_dns_controller_manager_image_name: "docker-images.third-party.gardener.dns-controller-manager.name"
     gardener_metrics_exporter_image_tag: "docker-images.third-party.gardener.metrics-exporter.tag"
     gardener_metrics_exporter_image_name: "docker-images.third-party.gardener.metrics-exporter.name"
     gardener_extension_acl_image_name: "docker-images.third-party.gardener.acl-extension.name"


### PR DESCRIPTION
## Description

The shoot-dns extension ships with the proper version of this component. In order not to have to maintain this dependency anymore, we remove the override from our release vector. Instead an operator can now manually provide an overwrite.

### Required Actions

```ACTIONS_REQUIRED
The deployment for the shoot-dns-service extension does not use the overwrite from our release vector for the dns-controller-manager subcomponent anymore. Operators who use a custom overwrite for this component now need to provide it through the new variables `gardener_shoot_dns_service_dns_controller_manager_image_name` and `gardener_shoot_dns_service_dns_controller_manager_image_tag`.
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You can add something to the release notes for the next metal-stack release (metal-stack/releases)? You can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

If your changes contain a breaking change, please add the following section:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```


### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
