### PR TITLE
No NSQ used in metal-core

### DIFF
--- a/partition/roles/metal-core/templates/metal-core-env.j2
+++ b/partition/roles/metal-core/templates/metal-core-env.j2
@@ -5,7 +5,6 @@ METAL_CORE_CIDR: "{{ metal_core_cidr }}"
 METAL_CORE_PARTITION_ID: "{{ metal_partition_id }}"
 METAL_CORE_RACK_ID: "{{ metal_core_rack_id }}"
 METAL_CORE_BIND_ADDRESS: 0.0.0.0
-METAL_CORE_SWITCH_TOPIC: "{{ metal_partition_id }}-switch"
 METAL_CORE_METAL_API_IP: "{{ metal_partition_metal_api_addr }}"
 METAL_CORE_METAL_API_PORT: "{{ metal_partition_metal_api_port }}"
 METAL_CORE_METAL_API_PROTOCOL: "{{ metal_partition_metal_api_protocol }}"


### PR DESCRIPTION
## Description

Found this by accident, nsq is no longer used in metal-core, so remove that.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You can add something to the release notes for the next metal-stack release (metal-stack/releases)? You can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

If your changes contain a breaking change, please add the following section:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```


### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
