### PR TITLE
Migrate to shoot_admin_kubeconfig

### DIFF
--- a/control-plane/roles/gardener-monitoring-certs/tasks/deploy_cert.yaml
+++ b/control-plane/roles/gardener-monitoring-certs/tasks/deploy_cert.yaml
@@ -1,8 +1,7 @@
 ---
 - name: Get seed kubeconfig
-  copy:
-    dest: "/tmp/kubeconfig.{{ gardener_shooted_seed.name }}"
-    content: "{{ lookup('k8s', kubeconfig='/tmp/kubeconfig.garden', api_version='v1', namespace='garden', kind='Secret', resource_name=gardener_shooted_seed.name+'.kubeconfig').get('data', {}).get('kubeconfig') | b64decode }}"
+  set_fact:
+    _seed_kubeconfig: "{{ gardener_seeds_virtual_garden_kubeconfig | shoot_admin_kubeconfig('garden', gardener_shooted_seed.name) | from_yaml }}"
 
 - name: Add seed ingress certificate
   k8s:
@@ -19,15 +18,21 @@
         secretRef:
           name: seed-ingress-certificate
           namespace: garden
-    kubeconfig: "/tmp/kubeconfig.{{ gardener_shooted_seed.name }}"
+    kubeconfig: "{{ _seed_kubeconfig }}"
+    apply: true
 
 - name: Wait until ingress secret is ready
-  command: echo
+  k8s_info:
+    api_version: v1
+    kind: Secret
+    name: seed-ingress-certificate
+    namespace: garden
+    kubeconfig: "{{ _seed_kubeconfig }}"
   changed_when: false
-  retries: 60
+  register: result
   delay: 10
-  until:
-    - lookup('k8s', kubeconfig='/tmp/kubeconfig.'+gardener_shooted_seed.name, api_version='v1', namespace='garden', kind='Secret', resource_name='seed-ingress-certificate')
+  retries: 60
+  until: result.resources | length > 0
 
 - name: Prepare seed ingress certificate secret
   k8s:
@@ -40,4 +45,5 @@
         name: seed-ingress-certificate
         namespace: garden
       type: kubernetes.io/tls
-    kubeconfig: "/tmp/kubeconfig.{{ gardener_shooted_seed.name }}"
+    kubeconfig: "{{ _seed_kubeconfig }}"
+    apply: true

--- a/control-plane/roles/gardener-monitoring-certs/tasks/main.yaml
+++ b/control-plane/roles/gardener-monitoring-certs/tasks/main.yaml
@@ -38,11 +38,6 @@
         namespace: garden
       type: kubernetes.io/tls
 
-- name: Write virtual garden kubeconfig
-  copy:
-    dest: "/tmp/kubeconfig.garden"
-    content: "{{ gardener_seeds_virtual_garden_kubeconfig }}"
-
 - name:  Loop over Gardener seeds
   include_tasks: deploy_cert.yaml
   loop: "{{ gardener_seeds_shooted_seeds }}"


### PR DESCRIPTION
## Description

Migrate to [dynamic kubeconfig generation](https://github.com/gardener/gardener/blob/master/docs/proposals/16-adminkubeconfig-subresource.md) in the role `gardener-monitoring-certs`.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You can add something to the release notes for the next metal-stack release (metal-stack/releases)? You can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

If your changes contain a breaking change, please add the following section:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```


### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
