### PR TITLE
Reboot mgmtserver if interfaces were not renamed successfully

### DIFF
--- a/partition/roles/systemd-networkd/tasks/main.yaml
+++ b/partition/roles/systemd-networkd/tasks/main.yaml
@@ -52,6 +52,13 @@
   loop_control:
     index_var: i
 
+- name: Update ansible facts
+  setup:
+
+- name: Reboot if interfaces were not renamed successfully
+  reboot:
+  when: "(systemd_networkd_nics | map(attribute='name')) is not subset(ansible_facts.interfaces)"
+
 - name: Render systemd-networkd vlan netdev config
   template:
     src: vlan.netdev.j2


### PR DESCRIPTION
Sometimes restarting systemd-networkd is not enough for the interface renaming to take effect. Therefore I added a check to see if the interfaces are renamed correctly and reboot the server if this is not the case.