### PR TITLE
Add ssh options to mgmt_server role

### DIFF
--- a/partition/roles/mgmt-server/README.md
+++ b/partition/roles/mgmt-server/README.md
@@ -16,6 +16,7 @@ Configures a server to act as management server for a metal-stack partition.
 | mgmt_server_nameservers               |           | the nameservers to use (default is dns0.eu).                                         |
 | mgmt_server_router_id                 | yes       | the router-id to use for routing.                                                    |
 | mgmt_server_spine_facing_interface    | yes       | the interface where the management spine is connected at the management server.      |
+| mgmt_server_metal_ssh_key_filename    |           | the filename of the private ssh key                                                  |
 | mgmt_server_metal_ssh_groups          |           | the ansible group to include into the ssh config                                     |
 | mgmt_server_metal_ssh_options         |           | the options to add globally to the ssh config                                        |
 | mgmt_server_metal_ssh_privkey         | yes       | the private SSH key of the `metal` admin user for connecting to the other components |

--- a/partition/roles/mgmt-server/README.md
+++ b/partition/roles/mgmt-server/README.md
@@ -17,6 +17,7 @@ Configures a server to act as management server for a metal-stack partition.
 | mgmt_server_router_id                 | yes       | the router-id to use for routing.                                                    |
 | mgmt_server_spine_facing_interface    | yes       | the interface where the management spine is connected at the management server.      |
 | mgmt_server_metal_ssh_groups          |           | the ansible group to include into the ssh config                                     |
+| mgmt_server_metal_ssh_options         |           | the options to add globally to the ssh config                                        |
 | mgmt_server_metal_ssh_privkey         | yes       | the private SSH key of the `metal` admin user for connecting to the other components |
 | mgmt_server_metal_ssh_pubkey          | yes       | the public SSH key of the `metal` admin user for connecting to the other components  |
 | mgmt_server_preserve_dhcp_route       | no        | preserve the dhcp (default) route the mgmt server got from the mgmt firewall         |

--- a/partition/roles/mgmt-server/defaults/main.yaml
+++ b/partition/roles/mgmt-server/defaults/main.yaml
@@ -22,4 +22,5 @@ mgmt_server_frr_repo: frr-8
 mgmt_server_provide_default_route: false
 
 mgmt_server_metal_ssh_groups: "{{ groups.all }}"
+mgmt_server_metal_ssh_options: []
 mgmt_server_metal_ssh_key_filename: id_rsa

--- a/partition/roles/mgmt-server/templates/ssh_config.j2
+++ b/partition/roles/mgmt-server/templates/ssh_config.j2
@@ -1,3 +1,6 @@
+{% for option in mgmt_server_metal_ssh_options %}
+{{ option}}
+{% endfor %}
 {% for host in mgmt_server_metal_ssh_groups %}
 {% if hostvars[host].ansible_host is defined %}
 {% if hostvars[host].ansible_user is defined %}


### PR DESCRIPTION
With newer versions of OpenSSH some options might become necessary that weren't needed before. For example, `PubkeyAcceptedKeyTypes=+ssh-rsa` is required to allow the use of deprecated `id_rsa` keys. 