### PR TITLE
Check if INTERFACE needs to be added to config_db in SONiC role

### DIFF
--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -70,8 +70,13 @@ MGMT_VRF_CONFIG:
   vrf_global:
     mgmtVrfEnabled: "{{ sonic_mgmt_vrf | lower }}"
 {% if sonic_ports_dict|length > 0 %}
+{% set ports_with_vrf_exist = sonic_ports_dict.items() | map('last') | map(attribute="vrf", default="") | select('regex', '.+') | length > 0 %}
+{% set ports_with_ips_exist = sonic_ports_dict.items() | map('last') | map(attribute="ips", default="") | select('regex', '.+') | length > 0 %}
+{% set ports_intersect_with_bgp_ports = sonic_ports_dict.items() | map('first') | intersect(sonic_bgp_ports) | length > 0 %}
+{% if ports_with_vrf_exist or ports_with_ips_exist or ports_intersect_with_bgp_ports %}
 
 INTERFACE:
+{% endif %}
   {% for name, port in sonic_ports_dict.items() %}
   {% if name in sonic_bgp_ports|default([]) or port.vrf is defined %}
   {{ name }}:


### PR DESCRIPTION
The template for the config_db.json currently has the problem of potentially adding `INTERFACE: null` to the config_db, which ruins all interface configuration. Unfortunately the scoping of jinja2 variables makes it impossible to change a variable value inside of a scope and access the updated value from a different scope (See [docs](https://jinja.palletsprojects.com/en/stable/templates/#assignments)). So I ended up using these complicated chains of filters. Better ideas are welcome.