### PR TITLE
Support unnumbered VLAN interfaces

### DIFF
--- a/partition/roles/systemd-networkd/templates/vlan.network.j2
+++ b/partition/roles/systemd-networkd/templates/vlan.network.j2
@@ -5,5 +5,7 @@ Type=vlan
 [Link]
 MTUBytes={{ item.mtu | default(systemd_networkd_mtu) }}
 
+{% if item.address is defined %}
 [Network]
 Address={{ item.address }}
+{% endif %}


### PR DESCRIPTION
## Description

With BGP unnumbered we do not need to specify specifc addresses for the counterparts.
This PR supports BGP unnumbered sessions over VLAN interfaces.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You can add something to the release notes for the next metal-stack release (metal-stack/releases)? You can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

If your changes contain a breaking change, please add the following section:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```


### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
