### PR TITLE
wait for connection after reboot

### DIFF
--- a/partition/roles/systemd-networkd/tasks/main.yaml
+++ b/partition/roles/systemd-networkd/tasks/main.yaml
@@ -56,7 +56,11 @@
   setup:
 
 - name: Reboot if interfaces were not renamed successfully
-  reboot:
+  block:
+    - name: Reboot
+      reboot:
+    - name: Wait for connection
+      wait_for_connection:
   when: "(systemd_networkd_nics | map(attribute='name')) is not subset(ansible_facts.interfaces)"
 
 - name: Render systemd-networkd vlan netdev config

--- a/partition/roles/systemd-networkd/tasks/main.yaml
+++ b/partition/roles/systemd-networkd/tasks/main.yaml
@@ -56,13 +56,13 @@
   setup:
 
 - name: Reboot if interfaces were not renamed successfully
-  block:
-    - name: Reboot
-      reboot:
-        reboot_timeout: 180
-      ignore_errors: true
-    - name: Wait for connection
-      wait_for_connection:
+  reboot:
+    reboot_timeout: 60
+  ignore_errors: true
+  when: "(systemd_networkd_nics | map(attribute='name')) is not subset(ansible_facts.interfaces)"
+
+- name: Wait for connection after reboot
+  wait_for_connection:
   when: "(systemd_networkd_nics | map(attribute='name')) is not subset(ansible_facts.interfaces)"
 
 - name: Render systemd-networkd vlan netdev config

--- a/partition/roles/systemd-networkd/tasks/main.yaml
+++ b/partition/roles/systemd-networkd/tasks/main.yaml
@@ -59,6 +59,8 @@
   block:
     - name: Reboot
       reboot:
+        reboot_timeout: 180
+      ignore_errors: true
     - name: Wait for connection
       wait_for_connection:
   when: "(systemd_networkd_nics | map(attribute='name')) is not subset(ansible_facts.interfaces)"

--- a/partition/roles/systemd-networkd/tasks/main.yaml
+++ b/partition/roles/systemd-networkd/tasks/main.yaml
@@ -56,13 +56,12 @@
   setup:
 
 - name: Reboot if interfaces were not renamed successfully
-  reboot:
-    reboot_timeout: 60
-  ignore_errors: true
-  when: "(systemd_networkd_nics | map(attribute='name')) is not subset(ansible_facts.interfaces)"
-
-- name: Wait for connection after reboot
-  wait_for_connection:
+  block:
+  - name: Reboot
+    command: reboot
+    become: true
+  - name: Wait for connection after reboot
+    wait_for_connection:
   when: "(systemd_networkd_nics | map(attribute='name')) is not subset(ansible_facts.interfaces)"
 
 - name: Render systemd-networkd vlan netdev config


### PR DESCRIPTION
## Description

This is an attempt to fix the issue, where a server gets rebooted and the connection times out despite the server having successfully booted.
As described [here](https://github.com/ansible/ansible/issues/79992), the `reboot` module sometimes has issues with reconnecting, while using `wait_for_connection` after `reboot` seems to work more reliably. 

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
