### PR TITLE
Allow multiple prometheus and promtail targets

### DIFF
--- a/partition/roles/monitoring/prometheus/README.md
+++ b/partition/roles/monitoring/prometheus/README.md
@@ -7,29 +7,27 @@ Deploys prometheus in a systemd-managed Docker container.
 This role uses variables from [partition-defaults](/partition). So, make sure
 you define them adequately as well.
 
-| Name                                             | Mandatory | Description                                                 |
-| ------------------------------------------------ | --------- | ----------------------------------------------------------- |
-| prometheus_port                                  |           | Port for prometheus                                         |
-| prometheus_image_name                            | yes       | Image version of the prometheus                             |
-| prometheus_image_tag                             | yes       | Image tag of the prometheus                                 |
-| prometheus_config_host_dir                       |           | The host directory for prometheus configurations            |
-| prometheus_data_host_dir                         |           | The host directory for prometheus data                      |
-| prometheus_alertmanager_target                   |           | Targets for the alertmanager                                |
-| prometheus_alertmanager_basic_auth_username      |           | The username for the authentication to the alertmanager     |
-| prometheus_alertmanager_basic_auth_password      |           | The password for the authentication to the alertmanager     |
-| prometheus_remote_write_url                      |           | Remote write target for prometheus                          |
-| prometheus_frr_exporter_targets                  |           | FRR exporter targets to scrape from                         |
-| prometheus_metal_core_targets                    |           | metal-core targets to scrape from                           |
-| prometheus_node_exporter_targets                 |           | Node exporter targets to scrape from                        |
-| prometheus_promtail_targets                      |           | Promtail targets to scrape from                             |
-| prometheus_ping_targets                          |           | Ping targets to scrape from                                 |
-| prometheus_sonic_exporter_targets                |           | Sonic exporter targets to scrape from                       |
-| prometheus_blackbox_exporter_targets             |           | Blackbox exporter targets to scrape from                    |
-| prometheus_lightbox_exporter_targets             |           | Lightbox exporter targets to scrape from                    |
-| prometheus_lightos_smart_targets                 |           | Lightos smart targets to scrape from                        |
-| prometheus_ipmi_exporter_targets                 |           | IPMI exporter targets to scrape from                        |
-| prometheus_hosts_content                         |           | Available hosts for prometheus                              |
-| prometheus_blackbox_exporter_icmp_groups         |           | ICMP groups for the blackbox exporter                       |
-| prometheus_blackbox_exporter_metal_api_probe_url |           | metal-api probe URL for the blackbox exporter               |
-| prometheus_remote_write_basic_auth_username      |           | The username for the prometheus remote write authentication |
-| prometheus_remote_write_basic_auth_password      |           | The password for the prometheus remote write authentication |
+| Name                                             | Mandatory | Description                                             |
+| ------------------------------------------------ | --------- | ------------------------------------------------------- |
+| prometheus_port                                  |           | Port for prometheus                                     |
+| prometheus_image_name                            | yes       | Image version of the prometheus                         |
+| prometheus_image_tag                             | yes       | Image tag of the prometheus                             |
+| prometheus_config_host_dir                       |           | The host directory for prometheus configurations        |
+| prometheus_data_host_dir                         |           | The host directory for prometheus data                  |
+| prometheus_alertmanager_target                   |           | Targets for the alertmanager                            |
+| prometheus_alertmanager_basic_auth_username      |           | The username for the authentication to the alertmanager |
+| prometheus_alertmanager_basic_auth_password      |           | The password for the authentication to the alertmanager |
+| prometheus_remote_write                          |           | Remote write target for prometheus                      |
+| prometheus_frr_exporter_targets                  |           | FRR exporter targets to scrape from                     |
+| prometheus_metal_core_targets                    |           | metal-core targets to scrape from                       |
+| prometheus_node_exporter_targets                 |           | Node exporter targets to scrape from                    |
+| prometheus_promtail_targets                      |           | Promtail targets to scrape from                         |
+| prometheus_ping_targets                          |           | Ping targets to scrape from                             |
+| prometheus_sonic_exporter_targets                |           | Sonic exporter targets to scrape from                   |
+| prometheus_blackbox_exporter_targets             |           | Blackbox exporter targets to scrape from                |
+| prometheus_lightbox_exporter_targets             |           | Lightbox exporter targets to scrape from                |
+| prometheus_lightos_smart_targets                 |           | Lightos smart targets to scrape from                    |
+| prometheus_ipmi_exporter_targets                 |           | IPMI exporter targets to scrape from                    |
+| prometheus_hosts_content                         |           | Available hosts for prometheus                          |
+| prometheus_blackbox_exporter_icmp_groups         |           | ICMP groups for the blackbox exporter                   |
+| prometheus_blackbox_exporter_metal_api_probe_url |           | metal-api probe URL for the blackbox exporter           |

--- a/partition/roles/monitoring/prometheus/README.md
+++ b/partition/roles/monitoring/prometheus/README.md
@@ -7,27 +7,27 @@ Deploys prometheus in a systemd-managed Docker container.
 This role uses variables from [partition-defaults](/partition). So, make sure
 you define them adequately as well.
 
-| Name                                             | Mandatory | Description                                             |
-| ------------------------------------------------ | --------- | ------------------------------------------------------- |
-| prometheus_port                                  |           | Port for prometheus                                     |
-| prometheus_image_name                            | yes       | Image version of the prometheus                         |
-| prometheus_image_tag                             | yes       | Image tag of the prometheus                             |
-| prometheus_config_host_dir                       |           | The host directory for prometheus configurations        |
-| prometheus_data_host_dir                         |           | The host directory for prometheus data                  |
-| prometheus_alertmanager_target                   |           | Targets for the alertmanager                            |
-| prometheus_alertmanager_basic_auth_username      |           | The username for the authentication to the alertmanager |
-| prometheus_alertmanager_basic_auth_password      |           | The password for the authentication to the alertmanager |
-| prometheus_remote_write                          |           | Remote write target for prometheus                      |
-| prometheus_frr_exporter_targets                  |           | FRR exporter targets to scrape from                     |
-| prometheus_metal_core_targets                    |           | metal-core targets to scrape from                       |
-| prometheus_node_exporter_targets                 |           | Node exporter targets to scrape from                    |
-| prometheus_promtail_targets                      |           | Promtail targets to scrape from                         |
-| prometheus_ping_targets                          |           | Ping targets to scrape from                             |
-| prometheus_sonic_exporter_targets                |           | Sonic exporter targets to scrape from                   |
-| prometheus_blackbox_exporter_targets             |           | Blackbox exporter targets to scrape from                |
-| prometheus_lightbox_exporter_targets             |           | Lightbox exporter targets to scrape from                |
-| prometheus_lightos_smart_targets                 |           | Lightos smart targets to scrape from                    |
-| prometheus_ipmi_exporter_targets                 |           | IPMI exporter targets to scrape from                    |
-| prometheus_hosts_content                         |           | Available hosts for prometheus                          |
-| prometheus_blackbox_exporter_icmp_groups         |           | ICMP groups for the blackbox exporter                   |
-| prometheus_blackbox_exporter_metal_api_probe_url |           | metal-api probe URL for the blackbox exporter           |
+| Name                                             | Mandatory | Description                                                                                                                               |
+| ------------------------------------------------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| prometheus_port                                  |           | Port for prometheus                                                                                                                       |
+| prometheus_image_name                            | yes       | Image version of the prometheus                                                                                                           |
+| prometheus_image_tag                             | yes       | Image tag of the prometheus                                                                                                               |
+| prometheus_config_host_dir                       |           | The host directory for prometheus configurations                                                                                          |
+| prometheus_data_host_dir                         |           | The host directory for prometheus data                                                                                                    |
+| prometheus_alertmanager_target                   |           | Targets for the alertmanager                                                                                                              |
+| prometheus_alertmanager_basic_auth_username      |           | The username for the authentication to the alertmanager                                                                                   |
+| prometheus_alertmanager_basic_auth_password      |           | The password for the authentication to the alertmanager                                                                                   |
+| prometheus_remote_write                          |           | A list of remote write targets for prometheus, see https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write |
+| prometheus_frr_exporter_targets                  |           | FRR exporter targets to scrape from                                                                                                       |
+| prometheus_metal_core_targets                    |           | metal-core targets to scrape from                                                                                                         |
+| prometheus_node_exporter_targets                 |           | Node exporter targets to scrape from                                                                                                      |
+| prometheus_promtail_targets                      |           | Promtail targets to scrape from                                                                                                           |
+| prometheus_ping_targets                          |           | Ping targets to scrape from                                                                                                               |
+| prometheus_sonic_exporter_targets                |           | Sonic exporter targets to scrape from                                                                                                     |
+| prometheus_blackbox_exporter_targets             |           | Blackbox exporter targets to scrape from                                                                                                  |
+| prometheus_lightbox_exporter_targets             |           | Lightbox exporter targets to scrape from                                                                                                  |
+| prometheus_lightos_smart_targets                 |           | Lightos smart targets to scrape from                                                                                                      |
+| prometheus_ipmi_exporter_targets                 |           | IPMI exporter targets to scrape from                                                                                                      |
+| prometheus_hosts_content                         |           | Available hosts for prometheus                                                                                                            |
+| prometheus_blackbox_exporter_icmp_groups         |           | ICMP groups for the blackbox exporter                                                                                                     |
+| prometheus_blackbox_exporter_metal_api_probe_url |           | metal-api probe URL for the blackbox exporter                                                                                             |

--- a/partition/roles/monitoring/prometheus/templates/prometheus.yaml.j2
+++ b/partition/roles/monitoring/prometheus/templates/prometheus.yaml.j2
@@ -31,14 +31,9 @@ alerting:
         - targets: [{{ prometheus_alertmanager_target }}]
 {% endif %}
 
-{% if prometheus_remote_write_url %}
+{% if prometheus_remote_write %}
 remote_write:
-- url: {{ prometheus_remote_write_url }}
-  {% if prometheus_remote_write_basic_auth_username is defined and prometheus_remote_write_basic_auth_password is defined %}
-  basic_auth:
-    username: {{ prometheus_remote_write_basic_auth_username }}
-    password: {{ prometheus_remote_write_basic_auth_password }}
-  {% endif %}
+{{ prometheus_remote_write | to_yaml(indent=2) }}
 {% endif %}
 
 # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.

--- a/partition/roles/promtail/README.md
+++ b/partition/roles/promtail/README.md
@@ -4,10 +4,10 @@ Deploys promtail in a systemd-managed Docker container.
 
 ## Variables
 
-| Name                     | Mandatory | Description                          |
-| ------------------------ | --------- | ------------------------------------ |
-| promtail_config_host_dir |           | The location of the promtail config  |
-| promtail_image_name      | yes       | Image version of the promtail        |
-| promtail_image_tag       | yes       | Image tag of the promtail            |
-| promtail_clients         | yes       | Configuration for promtail clients   |
-| promtail_scrape_configs  | yes       | A list containing the scrape configs |
+| Name                     | Mandatory | Description                                                                                                        |
+| ------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------ |
+| promtail_config_host_dir |           | The location of the promtail config                                                                                |
+| promtail_image_name      | yes       | Image version of the promtail                                                                                      |
+| promtail_image_tag       | yes       | Image tag of the promtail                                                                                          |
+| promtail_clients         | yes       | A list of clients for promtail, see https://grafana.com/docs/loki/latest/send-data/promtail/configuration/#clients |
+| promtail_scrape_configs  | yes       | A list containing the scrape configs                                                                               |

--- a/partition/roles/promtail/README.md
+++ b/partition/roles/promtail/README.md
@@ -4,12 +4,10 @@ Deploys promtail in a systemd-managed Docker container.
 
 ## Variables
 
-| Name                              | Mandatory | Description                                |
-| --------------------------------- | --------- | ------------------------------------------ |
-| promtail_config_host_dir          |           | The location of the promtail config        |
-| promtail_image_name               | yes       | Image version of the promtail              |
-| promtail_image_tag                | yes       | Image tag of the promtail                  |
-| promtail_loki_push_endpoint       | yes       | The URL to the Loki push endpoint          |
-| promtail_scrape_configs           | yes       | A list containing the scrape configs       |
-| promtail_loki_basic_auth_username |           | The username for the client authentication |
-| promtail_loki_basic_auth_password |           | The password for the client authentication |
+| Name                     | Mandatory | Description                          |
+| ------------------------ | --------- | ------------------------------------ |
+| promtail_config_host_dir |           | The location of the promtail config  |
+| promtail_image_name      | yes       | Image version of the promtail        |
+| promtail_image_tag       | yes       | Image tag of the promtail            |
+| promtail_clients         | yes       | Configuration for promtail clients   |
+| promtail_scrape_configs  | yes       | A list containing the scrape configs |

--- a/partition/roles/promtail/defaults/main/main.yaml
+++ b/partition/roles/promtail/defaults/main/main.yaml
@@ -1,5 +1,5 @@
 ---
 promtail_config_host_dir: "/etc/promtail"
 
-promtail_loki_push_endpoint:
+promtail_clients: []
 promtail_scrape_configs: []

--- a/partition/roles/promtail/tasks/main.yaml
+++ b/partition/roles/promtail/tasks/main.yaml
@@ -7,9 +7,9 @@
     fail_msg: "not all mandatory variables given, check role documentation"
     quiet: yes
     that:
+      - promtail_clients
       - promtail_image_tag is defined
       - promtail_image_name is defined
-      - promtail_loki_push_endpoint is not none
       - promtail_scrape_configs is defined and (promtail_scrape_configs|length>0)
 
 - name: Create promtail config directory

--- a/partition/roles/promtail/templates/promtail.yaml.j2
+++ b/partition/roles/promtail/templates/promtail.yaml.j2
@@ -6,13 +6,7 @@ positions:
   filename: /var/log/promtail-positions.yaml
 
 clients:
-  - url: {{ promtail_loki_push_endpoint }}
-    timeout: 60s
-    {% if promtail_loki_basic_auth_username is defined and promtail_loki_basic_auth_password is defined %}
-    basic_auth:
-      username: {{ promtail_loki_basic_auth_username }}
-      password: {{ promtail_loki_basic_auth_password }}
-    {% endif %}
+{{ promtail_clients | to_yaml(indent=2) }}
 
 scrape_configs:
-{{ promtail_scrape_configs|to_yaml(indent=2) }}
+{{ promtail_scrape_configs | to_yaml(indent=2) }}


### PR DESCRIPTION
## Description

This PR allows to configure multiple targets for Prometheus and Promtail.

### Required Actions

```ACTIONS_REQUIRED
For Prometheus, the ansible variables: `prometheus_remote_write_url`, `prometheus_remote_write_basic_auth_username` and `prometheus_remote_write_basic_auth_password` have been removed. Please use the new variable `prometheus_remote_write` instead for configuring the complete remote write target, e.g. with `basic_auth`. 
For Promtail, the ansible variables: `promtail_loki_push_endpoint`, `promtail_loki_basic_auth_username` and `promtail_loki_basic_auth_password` have been removed. Please use the new variable `promtail_clients` instead.
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
