### PR TITLE
Allow shooted seeds to be deployed with HA control plane.

### DIFF
--- a/control-plane/roles/gardener/defaults/main/gardener.yaml
+++ b/control-plane/roles/gardener/defaults/main/gardener.yaml
@@ -101,6 +101,8 @@ gardener_shooted_seeds: []
 #   verticalPodAutoscaler: false
 #   pod_cidr:
 #   service_cidr:
+#   # possible values are zone and node, please refer to the gardener documentation to what is appropriate for your environment:
+#   # https://gardener.cloud/docs/guides/high-availability/control-plane/
 #   high_availability_control_plane: node
 
 gardener_shooted_seed_max_pods: 250

--- a/control-plane/roles/gardener/defaults/main/gardener.yaml
+++ b/control-plane/roles/gardener/defaults/main/gardener.yaml
@@ -101,6 +101,7 @@ gardener_shooted_seeds: []
 #   verticalPodAutoscaler: false
 #   pod_cidr:
 #   service_cidr:
+#   high_availability_control_plane: node
 
 gardener_shooted_seed_max_pods: 250
 gardener_shooted_seed_node_cidr_mask_size: 23

--- a/control-plane/roles/gardener/templates/shooted-seed.j2
+++ b/control-plane/roles/gardener/templates/shooted-seed.j2
@@ -24,6 +24,12 @@ spec:
       enabled: false
     nginx-ingress:
       enabled: false
+{% if 'high_availability_control_plane' in gardener_shooted_seed %}
+  controlPlane:
+    highAvailability:
+      failureTolerance:
+        type: {{ gardener_shooted_seed.high_availability_control_plane }}
+{% endif %}
   kubernetes:
     version: "{{ gardener_shooted_seed.k8s_version }}"
     kubelet:


### PR DESCRIPTION
## Description

See description for the release notes.

### Noteworthy

```NOTEWORTHY
As with g/g v1.105 the `VPAForETCD` feature gate gets enabled unconditionally it is advised to use high-availiability for shoots to prevent unavailability of the ETCD during scaling. For the shooted seeds this can be configured by setting the new field `gardener_shooted_seed.high_availability_control_plane` to either `node` or `zone`.
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
