### PR TITLE
Adjustments to make static machine ports possible

### DIFF
--- a/partition/roles/sonic/README.md
+++ b/partition/roles/sonic/README.md
@@ -61,6 +61,7 @@ It depends on the `switch_facts` module from `ansible-common`, so make sure modu
 | sonic_interconnects.neighbor_ip                            |           | Connect to this BGP neighbors IP.                                                                                    |
 | sonic_interconnects.neighbors                              |           | Connect to this BGP neighbors - supports multiple neighbors and also BGP unnumbered by giving `Ethernet0 interface`. |
 | sonic_interconnects.unnumbered_interfaces                  |           | Connect with BGP unnumbered on these interfaces - also sets IPv6 options to make unnumbered work right.              |
+| sonic_interconnects.keep_private_as:                       |           | Do not remove the privates ASes on this interconnect. For use with static machine ports.                             |
 | sonic_interconnects.peer_group                             |           | Put the neighbor in this peer group.                                                                                 |
 | sonic_interconnects.evpn_peer                              |           | Whether the peer should take part in evpn routing (address-family l2vpn evpn)                                        |
 | sonic_interconnects.prefixlists                            |           | BGP prefix lists to configure.                                                                                       |

--- a/partition/roles/sonic/templates/frr.conf.j2
+++ b/partition/roles/sonic/templates/frr.conf.j2
@@ -26,12 +26,21 @@ interface {{ port }}
  no ipv6 nd suppress-ra
 {% endfor %}
 {% for k, i in sonic_interconnects.items() %}
+{% if i.vrf is defined %}
+{% for n in i.unnumbered_interfaces|default([]) %}
+!
+interface {{ n }} vrf {{ i.vrf }}
+ ipv6 nd ra-interval 6
+ no ipv6 nd suppress-ra
+{% endfor %}
+{% else %}
 {% for n in i.unnumbered_interfaces|default([]) %}
 !
 interface {{ n }}
  ipv6 nd ra-interval 6
  no ipv6 nd suppress-ra
 {% endfor %}
+{% endif %}
 {% endfor %}
 !
 router bgp {{ sonic_asn }}
@@ -136,7 +145,9 @@ router bgp {{ sonic_asn }} vrf {{ i.vrf }}
   {{ a }}
     {% endfor %}
     {% endif %}
+    {% if i.keep_private_as is not defined or i.keep_private_as is false %}
   neighbor {{ i.peer_group | default(sonic_interconnects_default_peer_group) }} remove-private-AS all
+    {% endif %}
     {% if i.routemap_in is defined %}
   neighbor {{ i.peer_group | default(sonic_interconnects_default_peer_group) }} route-map {{ i.routemap_in.name }} in
     {% endif %}

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -89,6 +89,19 @@ INTERFACE:
   {{ name }}|{{ ip }}: {}
   {% endfor %}
   {% endfor %}
+  {% if sonic_interconnects is defined and sonic_interconnects|length > 0 %}
+  {% for k, i in sonic_interconnects.items() %}
+  {% if i.unnumbered_interfaces is defined and i.unnumbered_interfaces|length > 0 %}
+  {% for interface in i.unnumbered_interfaces %}
+  {{ interface }}:
+    ipv6_use_link_local_only: enable
+    {% if i.vrf is defined %}
+    vrf_name: "{{ i.vrf }}"
+    {% endif %}
+  {% endfor %}
+  {% endif %}
+  {% endfor %}
+  {% endif %}
 {% endif %}
 {% if sonic_running_cfg_breakouts %}
 

--- a/partition/roles/sonic/test/data/exit/metal.yaml
+++ b/partition/roles/sonic/test/data/exit/metal.yaml
@@ -44,6 +44,8 @@ INTERFACE:
     ipv6_use_link_local_only: enable
   Ethernet116:
     ipv6_use_link_local_only: enable
+  Ethernet2:
+    ipv6_use_link_local_only: enable
 
 BREAKOUT_CFG:
   Ethernet0:

--- a/partition/roles/sonic/test/data/l2_leaf/frr.conf
+++ b/partition/roles/sonic/test/data/l2_leaf/frr.conf
@@ -10,11 +10,31 @@ vrf Vrf46
  vni 46
 exit-vrf
 !
+vrf Vrf64
+ vni 64
+exit-vrf
+!
 interface Ethernet120
  ipv6 nd ra-interval 6
  no ipv6 nd suppress-ra
 !
 interface Ethernet124
+ ipv6 nd ra-interval 6
+ no ipv6 nd suppress-ra
+!
+interface Ethernet96 vrf Vrf64
+ ipv6 nd ra-interval 6
+ no ipv6 nd suppress-ra
+!
+interface Ethernet100 vrf Vrf64
+ ipv6 nd ra-interval 6
+ no ipv6 nd suppress-ra
+!
+interface Ethernet104 vrf Vrf64
+ ipv6 nd ra-interval 6
+ no ipv6 nd suppress-ra
+!
+interface Ethernet108 vrf Vrf64
  ipv6 nd ra-interval 6
  no ipv6 nd suppress-ra
 !
@@ -58,6 +78,32 @@ router bgp 4200000000 vrf Vrf46
  address-family l2vpn evpn
   advertise ipv4 unicast
  exit-address-family
+!
+router bgp 4200000000 vrf Vrf64
+ bgp router-id 10.0.0.1
+ bgp bestpath as-path multipath-relax
+ neighbor STATIC peer-group
+ neighbor STATIC remote-as external
+ neighbor STATIC timers 1 3
+ neighbor Ethernet96 interface peer-group STATIC
+ neighbor Ethernet100 interface peer-group STATIC
+ neighbor Ethernet104 interface peer-group STATIC
+ neighbor Ethernet108 interface peer-group STATIC
+ !
+ address-family ipv4 unicast
+  redistribute connected
+  neighbor STATIC maximum-prefix 24000
+  neighbor STATIC route-map ALLOW-STATIC-IN in
+ exit-address-family
+ !
+ address-family l2vpn evpn
+  advertise ipv4 unicast
+ exit-address-family
+!
+ip prefix-list STATIC_PREFIX_IN seq 10 permit 10.64.64.0/22 ge 32
+!
+route-map ALLOW-STATIC-IN permit 10
+ match ip address prefix-list STATIC_PREFIX_IN
 !
 route-map LOOPBACKS permit 10
   match interface Loopback0

--- a/partition/roles/sonic/test/data/l2_leaf/input.yaml
+++ b/partition/roles/sonic/test/data/l2_leaf/input.yaml
@@ -15,6 +15,15 @@ sonic_ports_dict:
   Ethernet2:
   Ethernet4:
   Ethernet5:
+# static machines
+  Ethernet96:
+    speed: 100000
+  Ethernet100:
+    speed: 100000
+  Ethernet104:
+    speed: 100000
+  Ethernet108:
+    speed: 100000
 # L2 interconnects
   Ethernet112:
     speed: 100000
@@ -35,6 +44,14 @@ sonic_running_cfg_breakouts:
     brkout_mode: "4x25G"
   Ethernet4:
     brkout_mode: "4x25G"
+  Ethernet96:
+    brkout_mode: "1x100G[40G]"
+  Ethernet100:
+    brkout_mode: "1x100G[40G]"
+  Ethernet104:
+    brkout_mode: "1x100G[40G]"
+  Ethernet108:
+    brkout_mode: "1x100G[40G]"
   Ethernet112:
     brkout_mode: "1x100G[40G]"
   Ethernet116:
@@ -99,6 +116,30 @@ sonic_running_cfg_ports:
     lanes: "4"
     parent_port: Ethernet4
     speed: "25000"  
+  Ethernet96:
+    alias: Eth25(Port25)
+    index: "25"
+    lanes: "97,98,99,100"
+    parent_port: Ethernet96
+    speed: "100000"
+  Ethernet100:
+    alias: Eth26(Port26)
+    index: "26"
+    lanes: "101,102,103,104"
+    parent_port: Ethernet100
+    speed: "100000"
+  Ethernet104:
+    alias: Eth27(Port27)
+    index: "27"
+    lanes: "105,106,107,108"
+    parent_port: Ethernet104
+    speed: "100000"
+  Ethernet108:
+    alias: Eth28(Port28)
+    index: "28"
+    lanes: "109,110,111,112"
+    parent_port: Ethernet108
+    speed: "100000"
   Ethernet112:
     alias: Eth29(Port29)
     index: "29"
@@ -144,11 +185,16 @@ sonic_vlans:
   - PortChannel21
   - PortChannel22
   - PortChannel23
+- id: 1002
+  vrf: Vrf64
 
 sonic_vteps:
 - comment: "Croit storage"
   vlan: Vlan1001
   vni: 46
+- comment: "Static machines"
+  vlan: Vlan1002
+  vni: 64
 
 sonic_interconnects:
   croit:
@@ -161,6 +207,30 @@ sonic_interconnects:
     evpn_peer: true
     neighbor_ip: "192.168.255.2"
     remote_as: "4200000000"
+  static:
+    vrf: Vrf64
+    vni: 64
+    peer_group: "STATIC"
+    keep_private_as: true
+    unnumbered_interfaces:
+    - Ethernet96
+    - Ethernet100
+    - Ethernet104
+    - Ethernet108
+    announcements:
+    - "redistribute connected"
+    - "neighbor STATIC maximum-prefix 24000"
+    routemap_in: "{{ static_routemap_in }}"
+    prefixlists: "{{ static_prefixlists }}"
+
+static_prefixlists:
+- "ip prefix-list STATIC_PREFIX_IN seq 10 permit 10.64.64.0/22 ge 32"
+
+static_routemap_in:
+  name: ALLOW-STATIC-IN
+  entries:
+  - "match ip address prefix-list STATIC_PREFIX_IN"
+
 
 sonic_mclag:
   system_mac: 00:11:22:33:44:55

--- a/partition/roles/sonic/test/data/l2_leaf/metal.yaml
+++ b/partition/roles/sonic/test/data/l2_leaf/metal.yaml
@@ -62,12 +62,32 @@ INTERFACE:
     ipv6_use_link_local_only: enable
   Ethernet124:
     ipv6_use_link_local_only: enable
+  Ethernet96:
+    ipv6_use_link_local_only: enable
+    vrf_name: "Vrf64"
+  Ethernet100:
+    ipv6_use_link_local_only: enable
+    vrf_name: "Vrf64"
+  Ethernet104:
+    ipv6_use_link_local_only: enable
+    vrf_name: "Vrf64"
+  Ethernet108:
+    ipv6_use_link_local_only: enable
+    vrf_name: "Vrf64"
 
 BREAKOUT_CFG:
   Ethernet0:
     brkout_mode: "4x25G"
   Ethernet4:
     brkout_mode: "4x25G"
+  Ethernet96:
+    brkout_mode: "1x100G[40G]"
+  Ethernet100:
+    brkout_mode: "1x100G[40G]"
+  Ethernet104:
+    brkout_mode: "1x100G[40G]"
+  Ethernet108:
+    brkout_mode: "1x100G[40G]"
   Ethernet112:
     brkout_mode: "1x100G[40G]"
   Ethernet116:
@@ -154,6 +174,46 @@ PORT:
     parent_port: Ethernet4
     admin_status: up
     speed: "25000"
+  Ethernet96:
+    alias: Eth25(Port25)
+    autoneg: "off"
+    index: "25"
+    lanes: "97,98,99,100"
+    parent_port: Ethernet96
+    admin_status: up
+    speed: "100000"
+    mtu: "9000"
+    fec: none
+  Ethernet100:
+    alias: Eth26(Port26)
+    autoneg: "off"
+    index: "26"
+    lanes: "101,102,103,104"
+    parent_port: Ethernet100
+    admin_status: up
+    speed: "100000"
+    mtu: "9000"
+    fec: none
+  Ethernet104:
+    alias: Eth27(Port27)
+    autoneg: "off"
+    index: "27"
+    lanes: "105,106,107,108"
+    parent_port: Ethernet104
+    admin_status: up
+    speed: "100000"
+    mtu: "9000"
+    fec: none
+  Ethernet108:
+    alias: Eth28(Port28)
+    autoneg: "off"
+    index: "28"
+    lanes: "109,110,111,112"
+    parent_port: Ethernet108
+    admin_status: up
+    speed: "100000"
+    mtu: "9000"
+    fec: none
   Ethernet112:
     alias: Eth29(Port29)
     autoneg: "off"
@@ -260,6 +320,8 @@ VLAN:
     vlanid: 1000
   Vlan1001:
     vlanid: 1001
+  Vlan1002:
+    vlanid: 1002
 
 VLAN_INTERFACE:
   Vlan1000: {}
@@ -267,6 +329,8 @@ VLAN_INTERFACE:
   Vlan1001:
     static_anycast_gateway: "true"
     vrf_name: "Vrf46"
+  Vlan1002:
+    vrf_name: "Vrf64"
 
 VLAN_MEMBER:
   Vlan1000|PortChannel01:
@@ -297,10 +361,16 @@ VXLAN_TUNNEL_MAP:
   "vtep|map_46_Vlan1001":
     vlan: "Vlan1001"
     vni: "46"
+  # Static machines
+  "vtep|map_64_Vlan1002":
+    vlan: "Vlan1002"
+    vni: "64"
 
 VRF:
   Vrf46:
     vni: "46"
+  Vrf64:
+    vni: "64"
 
 LLDP:
   Global:


### PR DESCRIPTION
(cherry picked from commit 0342e666150c0c005fbbd2ff79c65a5276c23119)

## Description

Adjustments to the sonic role templates to make static machine ports possible on switches without metal-core; eg for some storage systems that can speak BGP.

Re-using the `sonic_interconnects` tree for this because it already contained almost all that was necessary.
