### PR TITLE
Configure lldp hello timer on upstream sonic

### DIFF
--- a/partition/roles/sonic/tasks/main.yaml
+++ b/partition/roles/sonic/tasks/main.yaml
@@ -60,5 +60,10 @@
   notify:
   - restart caclmgrd
 
+# upstream sonic cannot configure lldp so we set it here via lldpcli
+# this command can be safely run against edge-core sonic as well
+- name: set lldp hello timer
+  command: "lldpcli configure lldp tx-interval {{ sonic_lldp_hello_timer }}"
+
 - name: Flush handlers
   meta: flush_handlers


### PR DESCRIPTION
## Description

For edge-core SONiC we use a field in the `config_db.json` to configure LLDP hello timer. This field is missing in upstream SONiC, therefore `lldpcli` is used. Running the same command on an edge-core SONiC version 202111.4 works as well, so this change doesn't break anything.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
