### PR TITLE
Add retries to wait for metal-core to come up

### DIFF
--- a/partition/roles/metal-core/tasks/main.yaml
+++ b/partition/roles/metal-core/tasks/main.yaml
@@ -116,4 +116,4 @@
     retry_counter: 0
   include_tasks: wait_for_metal_core.yaml
   with_sequence: start=0 end={{ max_retries }}
-  when: "{{ result }} is defined and {{ result }} is failed"
+  until: result is defined and result is success

--- a/partition/roles/metal-core/tasks/main.yaml
+++ b/partition/roles/metal-core/tasks/main.yaml
@@ -117,4 +117,5 @@
   include_tasks: wait_for_metal_core.yaml
   with_sequence: start=0 end={{ max_retries }}
   loop_control:
-    break_when: result is success
+    break_when:
+      - result is success

--- a/partition/roles/metal-core/tasks/main.yaml
+++ b/partition/roles/metal-core/tasks/main.yaml
@@ -116,4 +116,4 @@
     retry_counter: 0
   include_tasks: wait_for_metal_core.yaml
   with_sequence: start=0 end={{ max_retries }}
-  when: result is failed
+  when: "{{ result }} is failed"

--- a/partition/roles/metal-core/tasks/main.yaml
+++ b/partition/roles/metal-core/tasks/main.yaml
@@ -116,6 +116,4 @@
     retry_counter: 0
   include_tasks: wait_for_metal_core.yaml
   with_sequence: start=0 end={{ max_retries }}
-  loop_control:
-    break_when:
-      - result is success
+  when: result is failed

--- a/partition/roles/metal-core/tasks/main.yaml
+++ b/partition/roles/metal-core/tasks/main.yaml
@@ -116,3 +116,5 @@
     retry_counter: 0
   include_tasks: wait_for_metal_core.yaml
   with_sequence: start=0 end={{ max_retries }}
+  loop_control:
+    break_when: result is success

--- a/partition/roles/metal-core/tasks/main.yaml
+++ b/partition/roles/metal-core/tasks/main.yaml
@@ -115,5 +115,5 @@
     max_retries: 5
     retry_counter: 0
   include_tasks: wait_for_metal_core.yaml
-  with_sequence: start=0 end={{ max_retries }}
+  loop: "{{ range(0, max_retries)|list }}"
   until: result is defined and result is success

--- a/partition/roles/metal-core/tasks/main.yaml
+++ b/partition/roles/metal-core/tasks/main.yaml
@@ -110,8 +110,9 @@
     systemd_service_bindsto: "{{ 'sonic.target' if metal_stack_switch_os_is_sonic }}"
     systemd_service_wants: "{{ 'database.service' if metal_stack_switch_os_is_sonic else 'docker.service' }}"
 
-- name: wait for metal-core to listen on metrics port
-  wait_for:
-    port: 2112
-    timeout: 300
-    msg: "metal-core did not come up"
+- name: wait for metal-core to come up
+  vars:
+    max_retries: 5
+    retry_counter: 0
+  include_tasks: wait_for_metal_core.yaml
+  with_sequence: start=0 end={{ max_retries }}

--- a/partition/roles/metal-core/tasks/main.yaml
+++ b/partition/roles/metal-core/tasks/main.yaml
@@ -116,4 +116,4 @@
     retry_counter: 0
   include_tasks: wait_for_metal_core.yaml
   with_sequence: start=0 end={{ max_retries }}
-  when: "{{ result }} is failed"
+  when: "{{ result }} is defined and {{ result }} is failed"

--- a/partition/roles/metal-core/tasks/wait_for_metal_core.yaml
+++ b/partition/roles/metal-core/tasks/wait_for_metal_core.yaml
@@ -1,0 +1,21 @@
+---
+- name: wait for metal-core to come up
+  block:
+    - name: wait for metal-core to listen on metrics port
+      wait_for:
+        port: 2112
+        timeout: 30
+      register: result
+
+  rescue:
+    - set_fact:
+        retry_counter: "{{ retry_counter | int + 1 }}"
+
+    - fail:
+        msg: metal-core did not come up
+      when: (retry_counter | int > max_retries | int)
+
+    - name: restart metal-core
+      service:
+        name: metal-core
+        state: restarted


### PR DESCRIPTION
## Description

Sometimes when metal-core does not come up a simple restart can fix it. Therefore, instead of simply waiting for metal-core to come up, a restart will be attempted 5 times before the task fails.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
