### PR TITLE
Add missing `metal_apiserver_admin_subjects` default variable.

### DIFF
--- a/control-plane/roles/metal/README.md
+++ b/control-plane/roles/metal/README.md
@@ -115,6 +115,7 @@ You can look up all the default values of this role [here](defaults/main/main.ya
 | metal_apiserver_oidc_end_session_url                                  |           | The URL for OIDC end session                                              |
 | metal_apiserver_oidc_client_id                                        |           | The OIDC provider's app client id                                         |
 | metal_apiserver_oidc_client_secret                                    |           | The OIDC provider's app client secret                                     |
+| metal_apiserver_admin_subjects                                        |           | A list of token subjects that are allowed to create admin tokens          |
 | metal_apiserver_session_secret                                        |           | The secret used to hash the sessions of a user during auth                |
 | metal_apiserver_hpa_enabled:                                          |           | Enables horizontal pod autoscaling for the metal-apiserver                |
 | metal_apiserver_hpa_max                                               |           | Max amount of replicas for the HPA of the metal-apiserver                 |

--- a/control-plane/roles/metal/defaults/main/main.yaml
+++ b/control-plane/roles/metal/defaults/main/main.yaml
@@ -51,6 +51,7 @@ metal_apiserver_oidc_end_session_url:
 metal_apiserver_oidc_client_id:
 metal_apiserver_oidc_client_secret:
 metal_apiserver_session_secret: secret
+metal_apiserver_admin_subjects: []
 
 # metal-api
 metal_api_image_pull_policy: "{{ metal_control_plane_image_pull_policy }}"


### PR DESCRIPTION
## Description

Yet another variable I forgot to add a default value to. :roll_eyes: 

Follow-up of #400. Has to go into metal-stack v0.21.1.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
