### PR TITLE
Create seed cluster role after starting up the virtual garden.

### DIFF
--- a/control-plane/roles/gardener/tasks/virtual_garden.yaml
+++ b/control-plane/roles/gardener/tasks/virtual_garden.yaml
@@ -48,3 +48,98 @@
     host: "{{ gardener_virtual_api_server_public_dns }}"
     port: "{{ gardener_virtual_api_server_public_port }}"
     timeout: 60
+
+# the admin kubeconfig is in the seeds group that gets created by the gardenlet.
+# to make it available earlier, let's create it with a custom admin cert
+#
+# we should move to the Gardener Operator soon to get rid off these hacks!
+
+- name: Create private key to setup virtual garden admin
+  community.crypto.openssl_privatekey:
+    path: "{{ gardener_local_tmp_dir }}/system-masters-kubeconfig-key"
+    type: ECC
+    size: 256
+    curve: secp256r1
+
+- name: Create certificate signing request
+  community.crypto.openssl_csr_pipe:
+    privatekey_path: "{{ gardener_local_tmp_dir }}/system-masters-kubeconfig-key"
+    common_name: admin
+    organization_name: system:masters
+    key_usage:
+      - digitalSignature
+      - keyEncipherment
+    extended_key_usage:
+      - serverAuth
+      - clientAuth
+  register: result
+
+- name: Create certificate
+  community.crypto.x509_certificate:
+    csr_content: "{{ result.csr }}"
+    path: "{{ gardener_local_tmp_dir }}/system-masters-kubeconfig-cert"
+    privatekey_path: "{{ gardener_local_tmp_dir }}/system-masters-kubeconfig-key"
+    ownca_content: "{{ gardener_kube_api_server_ca }}"
+    ownca_privatekey_content: "{{ gardener_kube_api_server_ca_key }}"
+    provider: ownca
+    return_content: true
+  register: result
+
+- name: Write the kubeconfig
+  copy:
+    dest: "{{ gardener_local_tmp_dir }}/system-masters-kubeconfig"
+    content: "{{ (gardener_virtual_api_server_public_dns + ':' + (gardener_virtual_api_server_public_port | string)) | kubeconfig_from_cert(gardener_kube_api_server_ca, result.certificate, lookup('file', gardener_local_tmp_dir + '/system-masters-kubeconfig-key'), prepend_https=true) }}"
+
+- name: Create gardener seeds cluster role
+  k8s:
+    kubeconfig: "{{ gardener_local_tmp_dir }}/system-masters-kubeconfig"
+    apply: true
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: gardener.cloud:system:seeds
+        annotations:
+          meta.helm.sh/release-name: controlplane
+          meta.helm.sh/release-namespace: garden
+        labels:
+          app.kubernetes.io/managed-by: Helm
+      rules:
+      - apiGroups:
+        - '*'
+        resources:
+        - '*'
+        verbs:
+        - '*'
+
+- name: Create gardener seeds cluster role binding
+  k8s:
+    kubeconfig: "{{ gardener_local_tmp_dir }}/system-masters-kubeconfig"
+    apply: true
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: gardener.cloud:system:seeds
+        annotations:
+          meta.helm.sh/release-name: controlplane
+          meta.helm.sh/release-namespace: garden
+        labels:
+          app.kubernetes.io/managed-by: Helm
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: gardener.cloud:system:seeds
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: gardener.cloud:system:seeds
+
+- name: Cleanup these certificates again
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ gardener_local_tmp_dir }}/system-masters-kubeconfig"
+    - "{{ gardener_local_tmp_dir }}/system-masters-kubeconfig-cert"
+    - "{{ gardener_local_tmp_dir }}/system-masters-kubeconfig-key"


### PR DESCRIPTION
## Description

This is a follow-up of https://github.com/metal-stack/mini-lab/pull/233 for initial bootstrapping of the Gardener as long as the corresponding role for the seeds was not yet created by a gardenlet. This is a workaround until we migrate to the Gardener Operator after we reached support for K8s 1.32.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
