### PR TITLE
Removed unsupported taint keys

### DIFF
--- a/control-plane/roles/gardener/templates/gardener-soil-project.yaml.j2
+++ b/control-plane/roles/gardener/templates/gardener-soil-project.yaml.j2
@@ -10,12 +10,8 @@ spec:
   tolerations:
     defaults:
       - key: seed.gardener.cloud/protected
-      - key: seed.gardener.cloud/invisible
-      - key: seed.gardener.cloud/disable-capacity-reservation
     whitelist:
       - key: seed.gardener.cloud/protected
-      - key: seed.gardener.cloud/invisible
-      - key: seed.gardener.cloud/disable-capacity-reservation
   owner:
     apiGroup: rbac.authorization.k8s.io
     kind: User

--- a/control-plane/roles/gardener/templates/gardenlet-values.j2
+++ b/control-plane/roles/gardener/templates/gardenlet-values.j2
@@ -70,8 +70,6 @@ config:
           enabled: {{ gardener_soil_vertical_pod_autoscaler_enabled }}
       taints:
       - key: seed.gardener.cloud/protected
-      - key: seed.gardener.cloud/invisible
-      - key: seed.gardener.cloud/disable-capacity-reservation
 
   featureGates: {{ gardener_gardenlet_feature_gates | to_json }}
 

--- a/control-plane/roles/gardener/templates/shooted-seed.j2
+++ b/control-plane/roles/gardener/templates/shooted-seed.j2
@@ -17,8 +17,6 @@ spec:
   purpose: infrastructure
   tolerations:
     - key: seed.gardener.cloud/protected
-    - key: seed.gardener.cloud/invisible
-    - key: seed.gardener.cloud/disable-capacity-reservation
   addons:
     kubernetes-dashboard:
       enabled: false

--- a/control-plane/roles/gardener/test/mock/gardener_soil_project.yaml
+++ b/control-plane/roles/gardener/test/mock/gardener_soil_project.yaml
@@ -10,12 +10,8 @@ spec:
   tolerations:
     defaults:
       - key: seed.gardener.cloud/protected
-      - key: seed.gardener.cloud/invisible
-      - key: seed.gardener.cloud/disable-capacity-reservation
     whitelist:
       - key: seed.gardener.cloud/protected
-      - key: seed.gardener.cloud/invisible
-      - key: seed.gardener.cloud/disable-capacity-reservation
   owner:
     apiGroup: rbac.authorization.k8s.io
     kind: User


### PR DESCRIPTION
## Description

> In previous Gardener versions (< 1.5) these settings were controlled via taint keys (seed.gardener.cloud/{disable-capacity-reservation,invisible}). The taint keys are no longer supported and removed in version 1.12.

See: https://gardener.cloud/docs/gardener/seed_settings/#scheduling

Taint keys were deprecated in https://github.com/gardener/gardener/pull/2315

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
