### PR TITLE
Default ipv4 prefix for headscale was malformed

### DIFF
--- a/control-plane/roles/headscale/defaults/main/main.yaml
+++ b/control-plane/roles/headscale/defaults/main/main.yaml
@@ -15,5 +15,5 @@ headscale_resources:
 
 headscale_api_key_expiration: 365d
 
-headscale_ipv4_prefix: 100.64.0.0/1
+headscale_ipv4_prefix: 100.64.0.0/10
 headscale_ipv6_prefix: fd7a:115c:a1e0::/48


### PR DESCRIPTION
## Description

found this during adding headscale support in mini-lab:

```
headscale-5796f9b964-qcxfw headscale 2025-06-26T11:13:53Z WRN Prefix 100.64.0.0/1 is not in the 100.64.0.0/10 range. This is an unsupported configuration.
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
