### PR TITLE
Support ACLs and make it work with newer headscale

### DIFF
--- a/control-plane/roles/headscale/templates/headscale.yaml
+++ b/control-plane/roles/headscale/templates/headscale.yaml
@@ -31,6 +31,10 @@ data:
 
     dns:
       magic_dns: false
+      override_local_dns: false
+
+    policy:
+      mode: database
 
 ---
 apiVersion: v1


### PR DESCRIPTION
## Description

Preparation for upcoming headscale version v0.26.x.

headscale >= v0.26.x does not start if `override_local_dns` is not set to false.

Tested this configuration with v0.23.0 as working.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
