### PR TITLE
add ontap to gardener-operator

### DIFF
--- a/control-plane/roles/gardener-extensions/README.md
+++ b/control-plane/roles/gardener-extensions/README.md
@@ -163,3 +163,13 @@ Check out the Gardener project for further documentation on [gardener.cloud](htt
 | gardener_extension_shoot_dns_service_dns_controller_manager_image_name    |           | Setting an explicit image name for the dns-controller-manager                                           |
 | gardener_extension_shoot_dns_service_dns_controller_manager_image_tag     |           | Setting an explicit image tag for the dns-controller-manager                                            |
 | gardener_extension_shoot_dns_service_dns_provider_replication             |           | Enable provider replication feature for the shoot-service-dns extension                                 |
+
+### gardener-extension-ontap
+
+| Name                                             | Mandatory | Description                                                              |
+| ------------------------------------------------ | --------- | ------------------------------------------------------------------------ |
+| gardener_extension_ontap_enabled        |           | If enabled, deploys the extension                                        |
+| gardener_extension_ontap_helm_chart     |           | The ref to the helm oci artifact to deploy this extension                |
+| gardener_extension_ontap_helm_chart_tag |           | The tag of the helm oci artifact to deploy this extension                |
+| gardener_extension_ontap_image_name     |           | Setting an explicit image name for the gardener-extension-ontap |
+| gardener_extension_ontap_image_tag      |           | Setting an explicit image tag for the  gardener-extension-ontap |

--- a/control-plane/roles/gardener-extensions/defaults/main/ontap.yaml
+++ b/control-plane/roles/gardener-extensions/defaults/main/ontap.yaml
@@ -1,0 +1,4 @@
+---
+gardener_extension_ontap_enabled: false
+
+gardener_extension_ontap_helm_chart_tag: "{{ gardener_extension_ontap_image_tag }}"

--- a/control-plane/roles/gardener-extensions/tasks/main.yaml
+++ b/control-plane/roles/gardener-extensions/tasks/main.yaml
@@ -69,3 +69,4 @@
     - provider-metal
     - shoot-cert-service
     - shoot-dns-service
+    - ontap

--- a/control-plane/roles/gardener-extensions/templates/ontap.yaml
+++ b/control-plane/roles/gardener-extensions/templates/ontap.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  name: ontap
+spec:
+  resources:
+  - kind: Extension
+    type: ontap
+  deployment:
+    extension:
+      policy: Always
+      helm:
+          ociRepository:
+            ref: "{{ gardener_extension_ontap_helm_chart }}:{{ gardener_extension_ontap_helm_chart_tag }}"
+      values:
+        image:
+          repository: "{{ gardener_extension_ontap_image_name }}"
+          tag: "{{ gardener_extension_ontap_image_tag }}"
+          pullPolicy: {{ metal_control_plane_image_pull_policy }}
+      runtimeClusterValues: {}


### PR DESCRIPTION
## Description

Adding the gardener extension for ontap to the new gardener operator role, like described in the [issue in ontap-extension repository.](https://github.com/metal-stack/gardener-extension-ontap/issues/15)

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
