### PR TITLE
Use `metal-view` as hmac default variable for `metal-metrics-exporter`

### DIFF
--- a/control-plane/roles/monitoring/defaults/main.yaml
+++ b/control-plane/roles/monitoring/defaults/main.yaml
@@ -31,6 +31,7 @@ monitoring_alertmanager_ingress_basic_auth_password_salt: "{{ monitoring_alertma
 # metal metrics exporter
 monitoring_metal_api_url: "http://metal-api.metal-control-plane.svc:8080/metal"
 monitoring_metal_api_hmac: "metal-view"
+monitoring_metal_api_authtype: "Metal-View"
 
 # rethinkdb exporter
 monitoring_rethinkdb_exporter_metal_db_password: "change-me"

--- a/control-plane/roles/monitoring/defaults/main.yaml
+++ b/control-plane/roles/monitoring/defaults/main.yaml
@@ -30,7 +30,7 @@ monitoring_alertmanager_ingress_basic_auth_password_salt: "{{ monitoring_alertma
 
 # metal metrics exporter
 monitoring_metal_api_url: "http://metal-api.metal-control-plane.svc:8080/metal"
-monitoring_metal_api_hmac: "metal-admin"
+monitoring_metal_api_hmac: "metal-view"
 
 # rethinkdb exporter
 monitoring_rethinkdb_exporter_metal_db_password: "change-me"

--- a/control-plane/roles/monitoring/templates/metrics-exporters/metal-metrics-exporter.yaml
+++ b/control-plane/roles/monitoring/templates/metrics-exporters/metal-metrics-exporter.yaml
@@ -7,6 +7,7 @@ type: Opaque
 stringData:
   url: {{ monitoring_metal_api_url }}
   hmac: {{ monitoring_metal_api_hmac }}
+  authtype: {{ monitoring_metal_api_authtype }}
 ---
 apiVersion: v1
 kind: Service
@@ -59,4 +60,8 @@ spec:
                 secretKeyRef:
                   name: metal-metrics-exporter-config
                   key: hmac
-
+            - name: METAL_API_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: metal-metrics-exporter-config
+                  key: authtype


### PR DESCRIPTION
## Description

The `metal-metrics-exporter` needs a `view` HMAC. This pull request makes this even clearer.

Related to: https://github.com/metal-stack/metal-metrics-exporter/pull/24

### Required Actions

```ACTIONS_REQUIRED
We recommend running the `metal-metrics-exporter` with a `Metal-View` auth type. The new Ansible variable `monitoring_metal_api_authtype` was introduced. By default, `Metal-View` is used. Please make sure, to update the auth type, if you want to run the exporter with higher privileges or verify, if `monitoring_metal_api_hmac` is configured correctly to be a view HMAC.
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
