### PR TITLE
Provide endpoints for gardener admission-metal.

### DIFF
--- a/control-plane/roles/gardener/tasks/admission_controllers.yaml
+++ b/control-plane/roles/gardener/tasks/admission_controllers.yaml
@@ -15,6 +15,43 @@
     helm_target_namespace: garden
     helm_value_file_template: extension-admission-metal-values.j2
 
+- name: Deploy service for admission-metal (in virtual apiserver)
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+          app: gardener-extension-admission-metal
+        name: gardener-extension-admission-metal
+        namespace: garden
+      spec:
+        ports:
+        - port: 443
+        selector:
+          app: gardener-extension-admission-metal
+    kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"
+    apply: yes
+
+- name: Deploy endpoints for admission-metal (in virtual apiserver)
+  k8s:
+    definition:
+      apiVersion: v1
+      kind: Endpoints
+      metadata:
+        labels:
+          app: gardener-extension-admission-metal
+        name: gardener-extension-admission-metal
+        namespace: garden
+      subsets:
+      - addresses:
+        - ip: "{{ lookup('k8s', api_version='v1', kind='Service', namespace='garden', resource_name='gardener-extension-admission-metal').get('spec').get('clusterIP') }}"
+        ports:
+        - port: 443
+          protocol: TCP
+    kubeconfig: "{{ gardener_kube_apiserver_kubeconfig_path }}"
+    apply: yes
+
 - name: "Register admission webhook: admission metal (in virtual apiserver)"
   include_role:
     name: ansible-common/roles/helm-chart


### PR DESCRIPTION
## Description

We observed that with g/g v1.116 it was not possible anymore to create shoots in new Gardener projects, seeing the following error message:

```
Error: [PUT /v1/cluster][500] createCluster default "{\"statuscode\":500,\"message\":\"secretbindings.core.gardener.cloud \\\"seed-provider-secret\\\" is forbidden: metal provider secret sanity check failed: Internal error occurred: failed calling webhook \\\"secrets.validator.admission-metal.extensions.gardener.cloud\\\": failed to call webhook: Post \\\"https://gardener-extension-admission-metal.garden.svc:443/webhooks/validate/secrets?timeout=10s\\\": service \\\"gardener-extension-admission-metal\\\" not found\"}"
```

We traced this back to a backport made to this version of Gardener, which added sanity checks of provider secrets: https://github.com/gardener/gardener/pull/12077.

With the gardener-operator we did not observe this issue, so we found a solution by adding a service and endpoints as for the exsiting `gardener-apiserver` communication of the virtual garden to it's runtime components. After migration to the gardener-operator this should not be required anymore.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
