### PR TITLE
Added vrrp to sonic_config role for gateway redundancy without vxlan

### DIFF
--- a/partition/roles/sonic-config/README.md
+++ b/partition/roles/sonic-config/README.md
@@ -552,6 +552,18 @@ sonic_config_vlans:
     # The VRF to bind to this VLAN.
     vrf: Vrf45
 
+    # VRRP: Gateway redundancy without Vxlan/EVPN. If you use Vxlan/EVPN you should configure SAG instead.
+    # Prerequisite: The two routers must be able to reach each other through this VLAN, and multicast VRRP packets (Multicast address 224.0.0.18, protocol 112) must not be blocked.
+    vrrp:
+      # The VRRP group. Should be unique per VLAN.
+      group: 1
+
+      # The VRRP priority. The router with the highest priority is master; in case of a tie the highest (VLAN) IP wins. Between 1 and 254.
+      priority: 50
+
+    # The VRRP IP. This is the virtual IP used as default gateway for the connected machines. It must not overlap with the VLAN ip.
+      ip: 10.255.1.1/24
+
 # VTEP configuration.
 sonic_config_vtep:
   # If enabled FRR will automatically advertise all VNIs.

--- a/partition/roles/sonic-config/templates/frr.conf.j2
+++ b/partition/roles/sonic-config/templates/frr.conf.j2
@@ -32,6 +32,17 @@ interface {{ n }}{% if i.vrf is defined %} vrf {{ i.vrf }}{% endif +%}
 !
 {% endfor %}
 {% endfor %}
+{% for vlan in sonic_config_vlans %}
+{% if vlan.vrrp is defined %}
+interface Vlan{{ vlan.id }}
+ vrrp {{ vlan.vrrp.group }}
+{% if vlan.vrrp.priority is defined %}
+ vrrp {{ vlan.vrrp.group }} priority {{ vlan.vrrp.priority }}
+{% endif %}
+ vrrp {{ vlan.vrrp.group }} ip {{ vlan.vrrp.ip|regex_replace('/.*','') }}
+!
+{% endif %}
+{% endfor %}
 router bgp {{ sonic_config_asn }}
  bgp router-id {{ sonic_config_loopback_address }}
  bgp bestpath as-path multipath-relax

--- a/partition/roles/sonic-config/test/data/exit/frr.conf
+++ b/partition/roles/sonic-config/test/data/exit/frr.conf
@@ -31,6 +31,11 @@ interface Ethernet2
  ipv6 nd ra-interval 6
  no ipv6 nd suppress-ra
 !
+interface Vlan4003
+ vrrp 1
+ vrrp 1 priority 66
+ vrrp 1 ip 10.1.1.1
+!
 router bgp 4200000000
  bgp router-id 10.0.0.1
  bgp bestpath as-path multipath-relax

--- a/partition/roles/sonic-config/test/data/exit/input.yaml
+++ b/partition/roles/sonic-config/test/data/exit/input.yaml
@@ -151,6 +151,12 @@ sonic_config_vlans:
     vrf: VrfMpls
   - id: 4001
     vrf: VrfTest
+  - id: 4003
+    ip: 192.168.0.1/24
+    vrrp:
+      group: 1
+      priority: 66
+      ip: 10.1.1.1/24
 
 sonic_config_vtep:
   enabled: true


### PR DESCRIPTION
## Description

This adds the possibility to configure vrrp in the sonic_config role.
This can be used to provide gateway redundancy when there is no vxlan/evpn; for example in an out of band management network.
