### PR TITLE
Fix bitnami valkey chart _needs_migration check

### DIFF
--- a/control-plane/roles/valkey/tasks/main.yaml
+++ b/control-plane/roles/valkey/tasks/main.yaml
@@ -19,7 +19,7 @@
 # TODO: tasks can be removed once migration can be assumed
 - name: Figure out if migration from bitnami chart is required
   set_fact:
-    _needs_migration: "{{ lookup('k8s', api_version='v1', kind='PersistentVolumeClaim', namespace=metal_control_plane_namespace, resource_name='valkey-data-valkey-replicas-0') }}"
+    _needs_migration: "{{ lookup('k8s', api_version='v1', kind='PersistentVolumeClaim', namespace=metal_control_plane_namespace, resource_name='valkey-data-valkey-replicas-0') | length > 0 }}"
 
 - name: "Migration: Remove old bitnami valkey chart"
   kubernetes.core.helm:


### PR DESCRIPTION
**Please double-check that `_needs_migration` when `length > 0` is indeed correct, I am not sure. I just assumed this was the intended behavior.**

While experimenting with the roles I ran into an ansible error after pulling a version of metal-roles with [this change](https://github.com/metal-stack/metal-roles/pull/473)

```
Task failed.
Origin: /home/geertjohan/.ansible/roles/metal-stack.metal-roles/control-plane/roles/valkey/tasks/main.yaml:24:3

22     _needs_migration: "{{ lookup('k8s', api_version='v1', kind='PersistentVolumeClaim', namespace=metal_control_pl...
23
24 - name: "Migration: Remove old bitnami valkey chart"
     ^ column 3

<<< caused by >>>

Conditional result (False) was derived from value of type 'list' at '/home/geertjohan/.ansible/roles/metal-stack.metal-roles/control-plane/roles/valkey/tasks/main.yaml:22:23'. Conditionals must have a boolean result.
Origin: /home/geertjohan/.ansible/roles/metal-stack.metal-roles/control-plane/roles/valkey/tasks/main.yaml:31:9

29     release_state: absent
30     wait: true
31   when: _needs_migration
           ^ column 9
```