### PR TITLE
Fix indention of `shootAdminKubeconfigMaxExpiration`.

### DIFF
--- a/control-plane/roles/gardener-operator/templates/garden.yaml
+++ b/control-plane/roles/gardener-operator/templates/garden.yaml
@@ -192,7 +192,7 @@ spec:
       gardenerAPIServer:
         admissionPlugins:
         - name: ShootVPAEnabledByDefault
-      shootAdminKubeconfigMaxExpiration: "{{ gardener_operator_shoot_admin_kubeconfig_max_expiration }}"
+        shootAdminKubeconfigMaxExpiration: "{{ gardener_operator_shoot_admin_kubeconfig_max_expiration }}"
     #   - name: ShootDNSRewriting
     #     disabled: false
     #     config:


### PR DESCRIPTION
## Description

```
TASK [metal-roles/control-plane/roles/gardener-operator : Create Garden] *******
[WARNING]: unknown field
"spec.virtualCluster.gardener.shootAdminKubeconfigMaxExpiration"
``` 

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
