### PR TITLE
Ensure prometheus rules directory on mgmt-server.

### DIFF
--- a/partition/roles/monitoring/prometheus/tasks/main.yaml
+++ b/partition/roles/monitoring/prometheus/tasks/main.yaml
@@ -141,6 +141,11 @@
     dest: "{{ prometheus_config_host_dir }}/file_sd/blackbox-exporter.yaml"
   notify: restart prometheus
 
+- name: ensure rules directory
+  file:
+    path: "{{ prometheus_config_host_dir }}/rules"
+    state: directory
+
 - name: copy notification rules
   copy:
     content: |


### PR DESCRIPTION
## Description

Follow-up of #544. It was developed on a running setup, therefore we did not notice this regression.

From the mini-lab:

```
deploy-partition      | failed: [leaf01] (item={'file': 'sonic-exporter.yaml', 'content_var': 'partition_prometheus_rules_sonic_exporter'}) => 
deploy-partition      |     ansible_loop_var: item
deploy-partition      |     changed: false
deploy-partition      |     checksum: d7f13cf8deabaec3b7f26a8d1608e5feabc4282d
deploy-partition      |     item:
deploy-partition      |         content_var: partition_prometheus_rules_sonic_exporter
deploy-partition      |         file: sonic-exporter.yaml
deploy-partition      |     msg: Destination directory /etc/prometheus/rules does not exist
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
