### PR TITLE
Fix defaulting for HTTP Route in gardener-cloudprofile role.

### DIFF
--- a/control-plane/roles/gardener-cloud-profile/defaults/main/cloud_profile.yaml
+++ b/control-plane/roles/gardener-cloud-profile/defaults/main/cloud_profile.yaml
@@ -4,7 +4,7 @@ gardener_cloud_profile_wait_until_available: true
 
 gardener_cloud_profile_stage_name: "{{ metal_control_plane_stage_name }}"
 gardener_cloud_profile_metal_api_url: >-
-  {% if metal_api_httproute_enabled -%}
+  {% if metal_api_httproute_enabled is defined and metal_api_httproute_enabled -%}
   https://api.{{ metal_control_plane_gateway_dns }}
   {%- else -%}
   https://api.{{ metal_control_plane_ingress_dns }}


### PR DESCRIPTION
## Description

Regression of #594. Currently breaks the mini-lab because the variable `metal_api_httproute_enabled` is not defined in `group_vars`.

```
deploy-control-plane  | TASK [metal-roles/control-plane/roles/gardener-cloud-profile : Add Metal cloud profile] ***
deploy-control-plane  | fatal: [localhost]: FAILED! => 
deploy-control-plane  |     msg: |-
deploy-control-plane  |         The task includes an option with an undefined variable.. {% if metal_api_httproute_enabled -%} https://api.{{/ metal_control_plane_gateway_dns }} {%- else -%} https://api.{{/ metal_control_plane_ingress_dns }} {%- endif %}: 'metal_api_httproute_enabled' is undefined
deploy-control-plane  | 
deploy-control-plane  |         The error appears to be in '/root/.ansible/roles/metal-roles/control-plane/roles/gardener-cloud-profile/tasks/main.yaml': line 38, column 3, but may
deploy-control-plane  |         be elsewhere in the file depending on the exact syntax problem.
deploy-control-plane  | 
deploy-control-plane  |         The offending line appears to be:
deploy-control-plane  | 
deploy-control-plane  | 
deploy-control-plane  |         - name: Add Metal cloud profile
```

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
