### PR TITLE
Gardener adapt new cloudprofile spec.

### DIFF
--- a/control-plane/roles/gardener-shoots/templates/shoot.yaml.j2
+++ b/control-plane/roles/gardener-shoots/templates/shoot.yaml.j2
@@ -25,7 +25,8 @@ metadata:
 spec:
   seedName: "{{ _config.seed_name }}"
   credentialsBindingName: "{{ _config.credentials_binding_name | default(_config.name + '-provider-secret') }}"
-  cloudProfileName: metal
+  cloudProfile:
+    name: metal
   region: "{{ _config.region }}"
   purpose: "{{ _config.purpose }}"
 {% if 'managed_seed' in _config %}


### PR DESCRIPTION
## Description

From gardener-apiserver with shoots with K8s 1.34:

```
cloudProfileName must not be set. Instead, use spec.cloudProfile.name
```

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
