### PR TITLE
ansible-lint: fix key-order.

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -12,7 +12,6 @@ exclude_paths:
 # TODO: we need to gradually fix these!
 warn_list:
   - role-name
-  - key-order
   - schema
   - name
   - var-naming

--- a/common/roles/metal-deployment-token/tasks/main.yaml
+++ b/common/roles/metal-deployment-token/tasks/main.yaml
@@ -1,5 +1,8 @@
 ---
 - name: Create admin api token for the deployment
+  delegate_to: localhost
+  run_once: true
+  when: metal_deployment_admin_token is not defined
   block:
     - name: Wait until the metal-apiserver is running
       kubernetes.core.k8s_info:
@@ -30,7 +33,3 @@
     - name: Set deployment token
       set_fact:
         metal_deployment_admin_token: "{{ _generated_token.stdout_lines[-1] }}"
-
-  delegate_to: localhost
-  run_once: true
-  when: metal_deployment_admin_token is not defined

--- a/partition/roles/mgmt-server/tasks/main.yaml
+++ b/partition/roles/mgmt-server/tasks/main.yaml
@@ -44,6 +44,8 @@
     force_apt_get: true
 
 - name: install docker
+  when: "'docker.service' not in services"
+
   block:
     - name: add docker gpg key
       get_url:
@@ -59,8 +61,6 @@
       apt:
         name:
           - docker-ce
-  when: "'docker.service' not in services"
-
 - name: copy docker daemon.json
   template:
     src: daemon.json.j2

--- a/partition/roles/wireguard/tasks/main.yaml
+++ b/partition/roles/wireguard/tasks/main.yaml
@@ -42,6 +42,10 @@
   tags: wg-generate-keys
 
 - name: use pre-generated keys if defined
+  when:
+    - wireguard_public_key
+    - wireguard_private_key
+
   block:
     - name: store public key file
       copy:
@@ -53,10 +57,6 @@
         content: "{{ wireguard_private_key }}"
         dest: "{{ _private_key_file_path }}"
         mode: "0600"
-  when:
-    - wireguard_public_key
-    - wireguard_private_key
-
 - name: register if private key already exists
   stat:
     path: "{{ _private_key_file_path }}"
@@ -64,6 +64,9 @@
   tags: wg-generate-keys
 
 - name: generate wireguard key pair
+  when: not private_key_file_stat.stat.exists
+  tags: wg-generate-keys
+
   block:
     - name: generate wireguard private key
       shell: "wg genkey | tee {{ _private_key_file_path }}"
@@ -86,10 +89,9 @@
       debug:
         msg: "generated wireguard public key: {{ _wg_public_key }}"
 
-  when: not private_key_file_stat.stat.exists
-  tags: wg-generate-keys
-
 - name: write wireguard configuration
+  tags: wg-config
+
   block:
     - name: slurp private key file
       slurp:
@@ -108,8 +110,6 @@
         group: root
         mode: 640
       notify: enable and restart wireguard
-  tags: wg-config
-
 - name: start wireguard
   service:
     name: wg-quick@wg0


### PR DESCRIPTION
## Description

This one should not be so complicated. :sweat_smile: 

Running ansible-lint autofix for [key-order](https://docs.ansible.com/projects/lint/rules/key-order/).

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
