### PR TITLE
Fix regression that calico image overwrite was completely removed.

### DIFF
--- a/control-plane/roles/gardener-extensions/defaults/main/networking_calico.yaml
+++ b/control-plane/roles/gardener-extensions/defaults/main/networking_calico.yaml
@@ -5,7 +5,7 @@ gardener_extension_networking_calico_helm_chart_tag: "{{ gardener_extension_netw
 gardener_extension_admission_calico_helm_chart_runtime_tag: "{{ gardener_extension_networking_calico_image_tag }}"
 gardener_extension_admission_calico_helm_chart_application_tag: "{{ gardener_extension_networking_calico_image_tag }}"
 
-# gardener_extension_networking_calico_image_vector_overwrite: []
+gardener_extension_networking_calico_image_vector_overwrite: []
 # - name: <image-name>
 #   sourceRepository: /source/repository
 #   repository: /repository


### PR DESCRIPTION
## Description

Regression from https://github.com/metal-stack/metal-roles/pull/646 leading to failing deployments because the variable is now unset.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
