### PR TITLE
Enable thanos receive HA mode

### DIFF
--- a/control-plane/roles/monitoring/templates/thanos-values.yaml
+++ b/control-plane/roles/monitoring/templates/thanos-values.yaml
@@ -122,11 +122,29 @@ receive:
   readinessProbe:
     failureThreshold: {{ monitoring_thanos_receive_probe_failure_threshold }}
 
-  replicaCount: 2
+  mode: dual-mode
+  replicaCount: 3
+  service:
+    additionalHeadless: true
+
+receiveDistributor:
+  enabled: true
+  replicationFactor: 3
 
 
-{% if monitoring_thanos_receive_ingress_basic_auth_password %}
+{% if monitoring_thanos_receive_ingress_basic_auth_password or monitoring_thanos_object_store_config is not defined %}
 extraDeploy:
+{% endif %}
+{% if monitoring_thanos_object_store_config is not defined %}
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: thanos-objstore-secret
+  type: Opaque
+  stringData:
+    objstore.yml: ""
+{% endif %}
+{% if monitoring_thanos_receive_ingress_basic_auth_password %}
 - apiVersion: v1
   kind: Secret
   metadata:


### PR DESCRIPTION
## Description
It seems like the intention here was to create an HA setup for thanos-receive, but this requires some additional setup to be fully functional. As it stands both pods collect metrics independently of each other, however the querier would sample only one of the two pods for data that has not yet been uploaded to the object store, which leads to artifacting in that time range. 

There are two ways to deploy thanos receive in a HA configuration. One is standalone and the other is dual-mode. I believe dual-mode is better suited for deployment at scale. dual-mode splits the receive pod into routers and ingesters. Without this configuration all receive pods must flush their data when scaling, leading to a short outage. https://thanos.io/tip/proposals-accepted/202012-receive-split.md

I set the default replicaCount to 3 to allow the ingesters to still form quorum when a single pod fails. 2 pods are not fault tolerant, so in case of a single pod failing, the other would refuse writes. The cost is that proper HA will also send 3 copies of the metrics to storage, leading to an increase in storage. The compactor could collapse the stream if desired.

The dummy secret is only really necessary when no object storage is configured, as is the case in the mini-lab. For the mini-lab specifically it may be worthwhile to override this back ot standalone with a single replica to save RAM.

closes: #664

#### Used AI-Tools ✨

 - None