### PR TITLE
Read admin token from secret instead of execing into metal-apiserver.

### DIFF
--- a/common/roles/metal-deployment-token/README.md
+++ b/common/roles/metal-deployment-token/README.md
@@ -1,12 +1,12 @@
 # metal-deployment-token
 
-This role can be used to create a short-lives admin deployment token intended for deploying infra services. Typically these require a dedicated tenant and a specific api token. The token is created through the metal-apiserver CLI through Kubernetes pod exec. So, it is required to have a connection to the Kubernetes cluster where the metal-apiserver is running.
+This role can be used to fetch the metal-apiserver admin deployment token intended for deploying infra services. Typically the services to deploy require a dedicated tenant and a specific api token. The token is created by the metal-control-plane helm-chart and stored as a secret in the metal-control-plane namespace where the metal-apiserver is running. So, it is required to have a connection to the Kubernetes cluster where the metal-apiserver is running.
+
+For partition deployments we recommend to just provide a deployment token issued by hand and store this token in the deployment variables.
 
 All tasks for this are run on the deployment machine (`localhost`). The token is then exported with the name `metal_deployment_admin_token` as an Ansible fact for the `localhost`.
 
-If a connection to the control plane Kubernetes cluster is unwanted, another option for the deployment would be to create a long-lived token for the deployment and just set `metal_deployment_admin_token` in `host_vars` for `localhost`. Then this role can be quickly swapped in or out.
-
-Please note that the created token has admin privileges by nature and expires fairly quickly. The created token is only intended to live during a CI deployment. It should not be stored on a target host.
+Please note that the created token has admin privileges by nature and expires after 8 hours. It should not be stored on a target host.
 
 ## Requirements
 
@@ -16,7 +16,8 @@ Please note that the created token has admin privileges by nature and expires fa
 
 You can look up all the default values of this role [here](defaults/main.yaml).
 
-| Name                              | Mandatory | Description                         |
-| --------------------------------- | --------- | ----------------------------------- |
-| metal_deployment_token_admin_role |           | The admin role to be created        |
-| metal_deployment_token_expiration |           | The expiration of the created token |
+| Name                                    | Mandatory | Description                                               |
+| --------------------------------------- | --------- | --------------------------------------------------------- |
+| metal_deployment_token_secret_name      |           | The secret name in which the admin token gets stored      |
+| metal_deployment_token_secret_namespace |           | The secret namespace in which the admin token gets stored |
+| metal_deployment_token_secret_key       |           | The secret key under which the admin token gets stored    |

--- a/common/roles/metal-deployment-token/defaults/main.yaml
+++ b/common/roles/metal-deployment-token/defaults/main.yaml
@@ -1,3 +1,4 @@
 ---
-metal_deployment_token_admin_role: ADMIN_ROLE_EDITOR
-metal_deployment_token_expiration: 1h
+metal_deployment_token_secret_name: metal-apiserver-admin-token
+metal_deployment_token_secret_namespace: "{{ metal_control_plane_namespace }}"
+metal_deployment_token_secret_key: admin_editor_token

--- a/common/roles/metal-deployment-token/meta/main.yml
+++ b/common/roles/metal-deployment-token/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   role_name: metal-deployment-token
   author: metal-stack
-  description: This role creates a deployment token and exports it in order to deploy infra services with it.
+  description: This role reads out an admin deployment token from the metal-apiserver and exports it in order to deploy infra services with it.
   license: MIT
   min_ansible_version: "2.18"
   galaxy_tags: []

--- a/common/roles/metal-deployment-token/tasks/main.yaml
+++ b/common/roles/metal-deployment-token/tasks/main.yaml
@@ -1,35 +1,17 @@
 ---
-- name: Create admin api token for the deployment
+- name: Set admin api token for deployment
   delegate_to: localhost
   run_once: true
   when: metal_deployment_admin_token is not defined
   block:
-    - name: Wait until the metal-apiserver is running
+    - name: Read metal-apiserver token secret
       kubernetes.core.k8s_info:
-        kind: Deployment
-        name: metal-apiserver
-        namespace: "{{ metal_control_plane_namespace }}"
-        wait: true
-        wait_sleep: 1
-        wait_timeout: 60
-
-    - name: Get metal-apiserver pods
-      ansible.builtin.set_fact:
-        _metal_apiserver_pod: "{{ (lookup('k8s', api_version='v1', kind='Pod', namespace=metal_control_plane_namespace, label_selector='app=metal-apiserver') | list_wrap)[0].get('metadata',
-          {}).get('name') }}"
-
-    - name: Generate deployment token
-      no_log: true
-      kubernetes.core.k8s_exec:
-        namespace: "{{ metal_control_plane_namespace }}"
-        pod: "{{ _metal_apiserver_pod }}"
-        command: |
-          /server token
-            --description=ansible-ci-deployment
-            --admin-role={{ metal_deployment_token_admin_role }}
-            --expiration={{ metal_deployment_token_expiration }}
-      register: _generated_token
+        api_version: v1
+        kind: Secret
+        name: "{{ metal_deployment_token_secret_name }}"
+        namespace: "{{ metal_deployment_token_secret_namespace }}"
+      register: _token_secret
 
     - name: Set deployment token
       ansible.builtin.set_fact:
-        metal_deployment_admin_token: "{{ _generated_token.stdout_lines[-1] }}"
+        metal_deployment_admin_token: "{{ _token_secret.resources[0].data[metal_deployment_token_secret_key] | b64decode }}"


### PR DESCRIPTION
## Description

With https://github.com/metal-stack/metal-apiserver/pull/231 we can now throw away the pod exec.

Closes #636.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
