### PR TITLE
mgmt-server: add optional static routes to the frr.conf template

### DIFF
--- a/partition/roles/mgmt-server/README.md
+++ b/partition/roles/mgmt-server/README.md
@@ -12,6 +12,7 @@ Configures a server to act as management server for a metal-stack partition.
 | mgmt_server_firewall_ip               |           | the remote ip of the firewall for setting up a numbered BGP session.                 |
 | mgmt_server_frr_match_interfaces      |           | announce the networks attached to the given interfaces over BGP.                     |
 | mgmt_server_frr_repo                  |           | the FRR repo to use.                                                                 |
+| mgmt_server_frr_static_routes         |           | additional static routes rendered into frr.conf, e.g. `["10.4.0.0/24 10.130.0.1"]`.  |
 | mgmt_server_frr_version               |           | the FRR version to use.                                                              |
 | mgmt_server_nameservers               |           | the nameservers to use (default is dns0.eu).                                         |
 | mgmt_server_router_id                 | yes       | the router-id to use for routing.                                                    |

--- a/partition/roles/mgmt-server/defaults/main.yaml
+++ b/partition/roles/mgmt-server/defaults/main.yaml
@@ -19,6 +19,7 @@ mgmt_server_frr_match_interfaces:
 
 mgmt_server_frr_version: 8.5-0
 mgmt_server_frr_repo: frr-8
+mgmt_server_frr_static_routes: []
 mgmt_server_provide_default_route: false
 
 mgmt_server_metal_ssh_groups: "{{ groups.all }}"

--- a/partition/roles/mgmt-server/templates/frr.conf.j2
+++ b/partition/roles/mgmt-server/templates/frr.conf.j2
@@ -9,6 +9,12 @@ debug bgp nht
 debug bgp update-groups
 debug bgp zebra
 !
+{% for route in mgmt_server_frr_static_routes %}
+ip route {{ route }}
+{% endfor %}
+{% if mgmt_server_frr_static_routes | length > 0 %}
+!
+{% endif %}
 interface {{ mgmt_server_spine_facing_interface }}
  ipv6 nd ra-interval 6
  no ipv6 nd suppress-ra


### PR DESCRIPTION
The mgmt-server role owns and regenerates /etc/frr/frr.conf, so a deployment that needs a static route in FRR has no first-class place to put it. Adding it out-of-band does not work either: a vtysh command plus write memory after the role overwrites the role-rendered file with the running config, silently rolling back every role-driven FRR change on the next apply.

Add mgmt_server_frr_static_routes, a list of 'prefix nexthop' strings rendered as ip route entries. The default is empty and renders nothing, so existing deployments are byte-identical.

Example use case: a partition whose PXE VLAN is routed to the mgmt server over the fabric needs a return route whose recursive next-hop must be resolved by FRR rather than the kernel.

#### Used AI-Tools ✨

Claude Fable 5