### PR TITLE
mgmt-server: render ssh_config hosts in stable order

### DIFF
--- a/partition/roles/mgmt-server/templates/ssh_config.j2
+++ b/partition/roles/mgmt-server/templates/ssh_config.j2
@@ -1,7 +1,7 @@
 {% for option in mgmt_server_metal_ssh_options %}
 {{ option}}
 {% endfor %}
-{% for host in mgmt_server_metal_ssh_groups %}
+{% for host in mgmt_server_metal_ssh_groups | sort %}
 {% if hostvars[host].ansible_host is defined %}
 {% if hostvars[host].ansible_user is defined %}
 Host {{ host }} {{ hostvars[host].host_alias|default('') }}


### PR DESCRIPTION
The ssh_config template iterates mgmt_server_metal_ssh_groups, which defaults to groups.all. Ansible does not guarantee a stable host ordering there, so the rendered /home/metal/.ssh/config flip-flops between runs: every apply reports the file as changed even when nothing was modified. Sort the hosts in the template so the rendered file is deterministic. Ordering of Host blocks has no semantic effect since every host gets its own block.

#### Used AI-Tools ✨

Claude Fable 5