### PR TITLE
mgmt-server: escape the pubkey in the authorized_keys regexp

### DIFF
--- a/partition/roles/mgmt-server/tasks/main.yaml
+++ b/partition/roles/mgmt-server/tasks/main.yaml
@@ -136,7 +136,7 @@
 - name: Add own ssh key to authorized_keys
   ansible.builtin.lineinfile:
     path: /home/metal/.ssh/authorized_keys
-    regexp: "^{{ mgmt_server_metal_ssh_pubkey }}$"
+    regexp: "^{{ mgmt_server_metal_ssh_pubkey | regex_escape }}$"
     line: "{{ mgmt_server_metal_ssh_pubkey }}"
 
 - name: Configure sshd to avoid root login and password authentication, hide OS information


### PR DESCRIPTION
The 'Add own ssh key to authorized_keys' lineinfile interpolates the public key unescaped into its regexp. Ssh public keys virtually always contain regex metacharacters ('+', '/'), so the pattern never matches the key already present in the file and the task appends a duplicate line on every apply.

#### Used AI-Tools ✨

Claude Fable 5