### PR TITLE
mgmt-server: fix iptables handler notify/listen case mismatch

### DIFF
--- a/partition/roles/mgmt-server/handlers/main.yaml
+++ b/partition/roles/mgmt-server/handlers/main.yaml
@@ -28,11 +28,11 @@
 
 - name: Save iptables v4 rules
   ansible.builtin.shell: iptables-save > /etc/iptables/rules.v4
-  listen: persist iptables
+  listen: Persist iptables
 
 - name: Save iptables v6 rules
   ansible.builtin.shell: ip6tables-save > /etc/iptables/rules.v6
-  listen: persist iptables
+  listen: Persist iptables
 
 - name: Restart sshd
   ansible.builtin.service:


### PR DESCRIPTION
tasks/main.yaml notifies 'Persist iptables' but the handlers listen on lowercase 'persist iptables'; ansible-core matches notify to listen case-sensitively. The mismatch is latent on a converged host because the notify only resolves when an iptables task reports changed, but a fresh mgmt-server fails the play with: The requested handler 'Persist iptables' was not found.

#### Used AI-Tools ✨

Claude Fable 5