### PR TITLE
Fix handler notify/listen case mismatches

### DIFF
--- a/partition/roles/mgmt-server/handlers/main.yaml
+++ b/partition/roles/mgmt-server/handlers/main.yaml
@@ -28,11 +28,11 @@
 
 - name: Save iptables v4 rules
   ansible.builtin.shell: iptables-save > /etc/iptables/rules.v4
-  listen: persist iptables
+  listen: Persist iptables
 
 - name: Save iptables v6 rules
   ansible.builtin.shell: ip6tables-save > /etc/iptables/rules.v6
-  listen: persist iptables
+  listen: Persist iptables
 
 - name: Restart sshd
   ansible.builtin.service:

--- a/partition/roles/systemd-networkd/handlers/main.yaml
+++ b/partition/roles/systemd-networkd/handlers/main.yaml
@@ -29,10 +29,10 @@
     owner: root
     group: root
     mode: "0755"
-  listen: rename interfaces
+  listen: Rename interfaces
 
 - name: Execute interface rename script
   ansible.builtin.command: /root/rename-interfaces.sh
   async: 300
   poll: 10
-  listen: rename interfaces
+  listen: Rename interfaces


### PR DESCRIPTION
Two roles notify handlers with capitalized names while the handlers listen on lowercase topics; ansible-core matches notify to listen case-sensitively, so the notifies never resolve:

- mgmt-server: 'Persist iptables' vs 'listen: persist iptables'
- systemd-networkd: 'Rename interfaces' vs 'listen: rename interfaces'

The mismatch is latent on a converged host because the notify only resolves when the notifying task reports changed, but on a fresh host the play fails with: The requested handler '...' was not found. Capitalize the listen topics to match the notifies (and the naming style of every other handler in the collection).

#### Used AI-Tools ✨

Claude Fable 5