### PR TITLE
Partition Prometheus Additional External Labels

### DIFF
--- a/partition/roles/monitoring/prometheus/README.md
+++ b/partition/roles/monitoring/prometheus/README.md
@@ -41,4 +41,5 @@ you define them adequately as well.
 | prometheus_scrape_interval                       |           | The frequency to scrape targets                                                                                                             |
 | prometheus_evaluation_interval                   |           | The frequency to evaluate rules                                                                                                             |
 | prometheus_scrape_timeout                        |           | Timeout per-scrape                                                                                                                          |
+| prometheus_additional_external_labels            |           | Additional external labels for Prometheus                                                                                                   |
 | prometheus_haproxy_enabled                       |           | Enable HAProxy metrics scraping                                                                                                             |

--- a/partition/roles/monitoring/prometheus/defaults/main.yaml
+++ b/partition/roles/monitoring/prometheus/defaults/main.yaml
@@ -5,6 +5,7 @@ prometheus_docker_log_driver: json-file
 prometheus_scrape_interval: 60s
 prometheus_evaluation_interval: 30s
 prometheus_scrape_timeout: 15s
+prometheus_additional_external_labels: {}
 
 prometheus_ipmi_scrape_interval: 10m
 prometheus_ipmi_scrape_timeout: 120s

--- a/partition/roles/monitoring/prometheus/defaults/main.yaml
+++ b/partition/roles/monitoring/prometheus/defaults/main.yaml
@@ -5,7 +5,8 @@ prometheus_docker_log_driver: json-file
 prometheus_scrape_interval: 60s
 prometheus_evaluation_interval: 30s
 prometheus_scrape_timeout: 15s
-prometheus_additional_external_labels: {}
+prometheus_additional_external_labels:
+  replica: "{{ inventory_hostname }}"
 
 prometheus_ipmi_scrape_interval: 10m
 prometheus_ipmi_scrape_timeout: 120s

--- a/partition/roles/monitoring/prometheus/templates/prometheus.yaml.j2
+++ b/partition/roles/monitoring/prometheus/templates/prometheus.yaml.j2
@@ -7,6 +7,9 @@ global:
   external_labels:
     partition: '{{ metal_partition_id }}'
     replica: '{{ inventory_hostname }}'
+{% for key, value in prometheus_additional_external_labels.items() %}
+    {{ key }}: "{{ value }}"
+{% endfor %}
 
 # Alertmanager configuration
 alerting:

--- a/partition/roles/monitoring/prometheus/templates/prometheus.yaml.j2
+++ b/partition/roles/monitoring/prometheus/templates/prometheus.yaml.j2
@@ -8,7 +8,7 @@ global:
     partition: '{{ metal_partition_id }}'
     replica: '{{ inventory_hostname }}'
 {% for key, value in prometheus_additional_external_labels.items() %}
-    {{ key }}: "{{ value }}"
+    {{ key }}: '{{ value }}'
 {% endfor %}
 
 # Alertmanager configuration

--- a/partition/roles/monitoring/prometheus/templates/prometheus.yaml.j2
+++ b/partition/roles/monitoring/prometheus/templates/prometheus.yaml.j2
@@ -6,7 +6,6 @@ global:
   scrape_timeout: {{ prometheus_scrape_timeout }}
   external_labels:
     partition: '{{ metal_partition_id }}'
-    replica: '{{ inventory_hostname }}'
 {% for key, value in prometheus_additional_external_labels.items() %}
     {{ key }}: '{{ value }}'
 {% endfor %}


### PR DESCRIPTION
## Description

Make it possible to add additional external labels to the partition Prometheus configuration. Necessary if using `remote_write` to send metrics to and use those external labels for filtering or providing unique metrics in the monitoring solution.

### Noteworthy

```NOTEWORTHY
Prometheus in the partition monitoring role can now be configured with additional labels. As some systems use `replica` while others use `__replica__` that may conflict, the label: `replica: '{{ inventory_hostname }}'` has been added to the defaults. If you make use of this configuration option and want to keep the `replica` label, make sure to include it explicitly.
```


#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
