### PR TITLE
Add argument_specs to roles for typed variable validation

### DIFF
--- a/common/roles/metal-deployment-token/meta/argument_specs.yaml
+++ b/common/roles/metal-deployment-token/meta/argument_specs.yaml
@@ -1,0 +1,18 @@
+---
+argument_specs:
+  main:
+    short_description: Reads the metal-apiserver admin token from a secret and provides it as metal_deployment_admin_token
+    options:
+      metal_deployment_token_secret_name:
+        type: str
+        description: Name of the secret containing the metal-apiserver admin token.
+      metal_deployment_token_secret_namespace:
+        type: str
+        description: Namespace of the secret containing the metal-apiserver admin token.
+      metal_deployment_token_secret_key:
+        type: str
+        description: Key within the secret data that contains the token.
+      metal_deployment_admin_token:
+        type: str
+        no_log: true
+        description: The admin token to use for deployment. When unset, it is read from the referenced secret.

--- a/common/roles/metal-v2-client/meta/argument_specs.yaml
+++ b/common/roles/metal-v2-client/meta/argument_specs.yaml
@@ -1,0 +1,11 @@
+---
+argument_specs:
+  main:
+    short_description: Installs the metal-stack-api python client library
+    options:
+      metal_v2_client_install_latest_on_version_error:
+        type: bool
+        description: Install the latest available client as fallback when the requested version is not available.
+      metal_v2_client_install_from_git_repository:
+        type: bool
+        description: Install the client from the git repository instead of PyPI.

--- a/control-plane/roles/auditing-timescaledb/meta/argument_specs.yaml
+++ b/control-plane/roles/auditing-timescaledb/meta/argument_specs.yaml
@@ -1,0 +1,100 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys a TimescaleDB for auditing via the postgres-backup-restore role
+    options:
+      auditing_timescaledb_name:
+        type: str
+        description: Name of the the auditing timescaledb deployment.
+      auditing_timescaledb_namespace:
+        type: str
+        description: The namespace to deploy the auditing timescaledb to.
+      auditing_timescaledb_image_pull_policy:
+        type: str
+        description: Image pull policy for the the auditing timescaledb container.
+      auditing_timescaledb_storage_size:
+        type: str
+        description: Size of the persistent volume.
+      auditing_timescaledb_storage_class:
+        type: str
+        description: Storage class of the persistent volume.
+      auditing_timescaledb_db:
+        type: str
+        description: Name of the database to create.
+      auditing_timescaledb_user:
+        type: str
+        description: User of the the auditing timescaledb database.
+      auditing_timescaledb_password:
+        type: str
+        no_log: true
+        description: Password of the the auditing timescaledb database.
+      auditing_timescaledb_max_connections:
+        type: raw
+        description: Maximum amount of database connections.
+      auditing_timescaledb_shared_libraries_preload:
+        type: list
+        elements: str
+        description: Libraries to preload via shared_preload_libraries.
+      auditing_timescaledb_backup_restore_sidecar_image_pull_policy:
+        type: str
+        description: Image pull policy for the backup-restore-sidecar container.
+      auditing_timescaledb_backup_restore_sidecar_provider:
+        type: str
+        description: Backup provider used by the backup-restore-sidecar (local, gcp or s3).
+      auditing_timescaledb_backup_restore_sidecar_backup_cron_schedule:
+        type: str
+        description: Cron schedule for creating backups.
+      auditing_timescaledb_backup_restore_sidecar_log_level:
+        type: str
+        description: Log level of the backup-restore-sidecar.
+      auditing_timescaledb_backup_restore_sidecar_object_prefix:
+        type: str
+        description: Object prefix used for backups in the object store.
+      auditing_timescaledb_backup_restore_sidecar_object_max_keep:
+        type: raw
+        description: Maximum amount of backup objects to keep.
+      auditing_timescaledb_backup_restore_sidecar_object_days_max_keep:
+        type: raw
+        description: Maximum age in days of backup objects to keep.
+      auditing_timescaledb_backup_restore_sidecar_s3_request_checksum_calculation:
+        type: str
+        description: S3 request checksum calculation setting (e.g. when_required for non-AWS S3 endpoints).
+      auditing_timescaledb_backup_restore_sidecar_gcp_bucket_name:
+        type: str
+        description: GCP bucket name for storing backups.
+      auditing_timescaledb_backup_restore_sidecar_gcp_backup_location:
+        type: str
+        description: GCP bucket location for storing backups.
+      auditing_timescaledb_backup_restore_sidecar_gcp_project_id:
+        type: str
+        description: GCP project id of the backup bucket.
+      auditing_timescaledb_backup_restore_sidecar_gcp_serviceaccount_json:
+        type: str
+        no_log: true
+        description: GCP service account JSON used for accessing the backup bucket.
+      auditing_timescaledb_backup_restore_sidecar_encryption_key:
+        type: str
+        no_log: true
+        description: Encryption key (32 characters) for encrypting backups.
+      auditing_timescaledb_resources:
+        type: dict
+        description: Resource requests and limits for the the auditing timescaledb container.
+      auditing_timescaledb_registry_auth_enabled:
+        type: raw
+        description: Whether to deploy an image pull secret for the registry.
+      auditing_timescaledb_registry_auth:
+        type: dict
+        no_log: true
+        description: Docker auth configuration for the image pull secret.
+      auditing_timescaledb_image_name:
+        type: str
+        description: Image name of the auditing timescaledb. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      auditing_timescaledb_image_tag:
+        type: str
+        description: Image tag of the auditing timescaledb. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      auditing_timescaledb_backup_restore_sidecar_image_name:
+        type: str
+        description: Image name of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      auditing_timescaledb_backup_restore_sidecar_image_tag:
+        type: str
+        description: Image tag of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.

--- a/control-plane/roles/gardener-cloud-profile/meta/argument_specs.yaml
+++ b/control-plane/roles/gardener-cloud-profile/meta/argument_specs.yaml
@@ -1,0 +1,48 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys the metal cloud profile to the virtual garden
+    options:
+      gardener_cloud_profile_garden_name:
+        type: str
+        description: Name of the garden to deploy the cloud profile to.
+      gardener_cloud_profile_wait_until_available:
+        type: bool
+        description: Whether to wait until the CloudProfile resource is available in the virtual garden.
+      gardener_cloud_profile_stage_name:
+        type: str
+        description: The stage name rendered into the cloud profile.
+      gardener_cloud_profile_metal_api_url:
+        type: str
+        description: The metal-api URL rendered into the cloud profile.
+      gardener_cloud_profile_machine_images:
+        type: list
+        elements: dict
+        description: Machine images offered in the cloud profile. Defaults to metal_api_images.
+      gardener_cloud_profile_firewall_images:
+        type: list
+        description: Firewall images offered in the cloud profile.
+      gardener_cloud_profile_firewall_images_from_machine_images:
+        type: bool
+        description: Whether firewall images are derived from the machine images.
+      gardener_cloud_profile_firewall_controller_versions:
+        type: list
+        description: Firewall controller versions offered in the cloud profile.
+      gardener_cloud_profile_kubernetes:
+        type: dict
+        description: The kubernetes section (expirable versions) of the cloud profile. Mandatory, must not be none.
+      gardener_cloud_profile_machine_types:
+        type: list
+        description: Machine types offered in the cloud profile.
+      gardener_cloud_profile_regions:
+        type: list
+        description: The regions section of the cloud profile. Mandatory, must not be none.
+      gardener_cloud_profile_partitions:
+        type: dict
+        description: Per-partition configuration (e.g. default machine types) of the cloud profile.
+      gardener_cloud_profile_os_cri_mapping:
+        type: dict
+        description: Mapping of operating systems to supported container runtimes.
+      gardener_cloud_profile_os_compatibility_mapping:
+        type: dict
+        description: Mapping of operating systems to kubelet compatibility constraints.

--- a/control-plane/roles/gardener-extensions/meta/argument_specs.yaml
+++ b/control-plane/roles/gardener-extensions/meta/argument_specs.yaml
@@ -1,0 +1,244 @@
+---
+argument_specs:
+  main:
+    short_description: Registers the gardener extensions and their admission controllers in the garden
+    options:
+      gardener_extension_acl_enabled:
+        type: bool
+        description: Whether the acl extension is registered.
+      gardener_extension_acl_helm_chart_tag:
+        type: str
+        description: Tag of the acl extension helm chart.
+      gardener_extension_admission_acl_helm_chart_application_tag:
+        type: str
+        description: Tag of the acl admission application helm chart.
+      gardener_extension_admission_acl_helm_chart_runtime_tag:
+        type: str
+        description: Tag of the acl admission runtime helm chart.
+      gardener_extension_acl_additional_allowed_cidrs:
+        type: list
+        elements: str
+        description: Additional CIDRs that are always allowed by the acl extension.
+      gardener_extension_audit_enabled:
+        type: bool
+        description: Whether the audit extension is registered.
+      gardener_extension_audit_helm_chart_tag:
+        type: str
+        description: Tag of the audit extension helm chart.
+      gardener_extension_audit_default_webhook_mode:
+        type: str
+        description: Default webhook mode of the audit extension.
+      gardener_extension_backup_s3_enabled:
+        type: bool
+        description: Whether the backup-s3 extension is registered.
+      gardener_extension_backup_s3_helm_chart_tag:
+        type: str
+        description: Tag of the backup-s3 extension helm chart.
+      gardener_extension_csi_driver_lvm_enabled:
+        type: bool
+        description: Whether the csi-driver-lvm extension is registered.
+      gardener_extension_csi_driver_lvm_helm_chart_tag:
+        type: str
+        description: Tag of the csi-driver-lvm extension helm chart.
+      gardener_extension_csi_driver_lvm_image_vector_overwrite:
+        type: list
+        description: Image vector overwrite for the csi-driver-lvm extension.
+      gardener_extension_dns_powerdns_enabled:
+        type: bool
+        description: Whether the dns-powerdns extension is registered.
+      gardener_extension_dns_powerdns_helm_chart_tag:
+        type: str
+        description: Tag of the dns-powerdns extension helm chart.
+      gardener_extension_dns_powerdns_additional_network_policies:
+        type: bool
+        description: Whether additional network policies are deployed for the dns-powerdns extension.
+      gardener_extension_duros_enabled:
+        type: bool
+        description: Whether the duros extension is registered.
+      gardener_extension_duros_helm_chart:
+        type: str
+        description: OCI reference of the duros extension helm chart. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      gardener_extension_duros_helm_chart_tag:
+        type: str
+        description: Tag of the duros extension helm chart.
+      gardener_extension_duros_image_name:
+        type: str
+        description: Image name of the duros extension.
+      gardener_extension_duros_image_tag:
+        type: str
+        description: Image tag of the duros extension.
+      gardener_extension_duros_regions_config:
+        type: dict
+        description: Per-region duros storage configuration.
+      gardener_extension_networking_calico_enabled:
+        type: bool
+        description: Whether the networking-calico extension is registered.
+      gardener_extension_networking_calico_helm_chart_tag:
+        type: str
+        description: Tag of the networking-calico extension helm chart.
+      gardener_extension_admission_calico_helm_chart_runtime_tag:
+        type: str
+        description: Tag of the calico admission runtime helm chart.
+      gardener_extension_admission_calico_helm_chart_application_tag:
+        type: str
+        description: Tag of the calico admission application helm chart.
+      gardener_extension_networking_calico_image_vector_overwrite:
+        type: list
+        description: Image vector overwrite for the networking-calico extension.
+      gardener_extension_networking_cilium_enabled:
+        type: bool
+        description: Whether the networking-cilium extension is registered.
+      gardener_extension_networking_cilium_helm_chart_tag:
+        type: str
+        description: Tag of the networking-cilium extension helm chart.
+      gardener_extension_admission_cilium_helm_chart_runtime_tag:
+        type: str
+        description: Tag of the cilium admission runtime helm chart.
+      gardener_extension_admission_cilium_helm_chart_application_tag:
+        type: str
+        description: Tag of the cilium admission application helm chart.
+      gardener_extension_networking_cilium_image_vector_overwrite:
+        type: list
+        description: Image vector overwrite for the networking-cilium extension.
+      gardener_extension_ontap_enabled:
+        type: bool
+        description: Whether the ontap extension is registered.
+      gardener_extension_ontap_helm_chart_tag:
+        type: str
+        description: Tag of the ontap extension helm chart.
+      gardener_extension_ontap_clusters:
+        type: list
+        description: The ONTAP clusters configured for the ontap extension.
+      gardener_extension_os_metal_enabled:
+        type: bool
+        description: Whether the os-metal extension is registered.
+      gardener_extension_os_metal_helm_chart_tag:
+        type: str
+        description: Tag of the os-metal extension helm chart.
+      gardener_extension_os_metal_types:
+        type: list
+        elements: str
+        description: The operating system types handled by the os-metal extension.
+      gardener_extension_provider_gcp_enabled:
+        type: bool
+        description: Whether the provider-gcp extension is registered.
+      gardener_extension_provider_gcp_helm_chart_tag:
+        type: str
+        description: Tag of the provider-gcp extension helm chart.
+      gardener_extension_admission_gcp_helm_chart_runtime_tag:
+        type: str
+        description: Tag of the gcp admission runtime helm chart.
+      gardener_extension_admission_gcp_helm_chart_application_tag:
+        type: str
+        description: Tag of the gcp admission application helm chart.
+      gardener_extension_provider_metal_enabled:
+        type: bool
+        description: Whether the provider-metal extension is registered.
+      gardener_extension_provider_metal_helm_chart_tag:
+        type: str
+        description: Tag of the provider-metal extension helm chart.
+      gardener_extension_admission_metal_helm_chart_runtime_tag:
+        type: str
+        description: Tag of the metal admission runtime helm chart.
+      gardener_extension_admission_metal_helm_chart_application_tag:
+        type: str
+        description: Tag of the metal admission application helm chart.
+      gardener_extension_provider_metal_admission_replicas:
+        type: int
+        description: Amount of replicas of the provider-metal admission controller.
+      gardener_extension_provider_metal_admission_vpa:
+        type: bool
+        description: Whether a vertical pod autoscaler is enabled for the provider-metal admission controller.
+      gardener_extension_provider_metal_admission_default_pods_cidr:
+        type: str
+        description: Default pods CIDR defaulted by the provider-metal admission controller.
+      gardener_extension_provider_metal_admission_default_services_cidr:
+        type: str
+        description: Default services CIDR defaulted by the provider-metal admission controller.
+      gardener_extension_provider_metal_etcd_storage_class_name:
+        type: str
+        description: Storage class of the shoot control plane etcd.
+      gardener_extension_provider_metal_etcd_backup_schedule:
+        type: str
+        description: Backup schedule of the shoot control plane etcd.
+      gardener_extension_provider_metal_etcd_delta_snapshot_period:
+        type: str
+        description: Delta snapshot period of the shoot control plane etcd.
+      gardener_extension_provider_metal_etcd_volume_eviction:
+        type: bool
+        description: Whether etcd pods are evicted on volume issues.
+      gardener_extension_provider_metal_egress_destinations:
+        type: list
+        description: Allowed egress destinations for shoot control planes.
+      gardener_extension_provider_metal_machine_images:
+        type: list
+        description: Machine image to firewall image mapping of the provider-metal extension. Defaults to metal_api_images.
+      gardener_extension_provider_metal_duros_storage_enabled:
+        type: bool
+        description: Whether duros storage integration is enabled in the provider-metal extension.
+      gardener_extension_provider_metal_duros_storage_config:
+        type: dict
+        description: Duros storage configuration of the provider-metal extension.
+      gardener_extension_provider_metal_image_pull_policy:
+        type: str
+        description: Image pull policy for the provider-metal extension containers.
+      gardener_extension_provider_metal_image_pull_secret:
+        type: str
+        description: Image pull secret encoded docker config for the provider-metal extension.
+      gardener_extension_provider_metal_firewall_internal_prefixes:
+        type: list
+        elements: str
+        description: Internal network prefixes for firewall rules of the provider-metal extension.
+      gardener_extension_provider_metal_additional_network_policies:
+        type: list
+        description: Additional network policies deployed by the provider-metal extension.
+      gardener_extension_shoot_cert_service_enabled:
+        type: bool
+        description: Whether the shoot-cert-service extension is registered.
+      gardener_extension_shoot_cert_service_helm_chart_tag:
+        type: str
+        description: Tag of the shoot-cert-service extension helm chart.
+      gardener_extension_shoot_cert_service_issuer_private_key:
+        type: str
+        no_log: true
+        description: Private key of the ACME issuer account.
+      gardener_extension_shoot_cert_service_issuer_server:
+        type: str
+        description: ACME server URL of the certificate issuer.
+      gardener_extension_shoot_cert_service_issuer_email:
+        type: str
+        description: Email address of the ACME issuer account. Required when the shoot-cert-service extension is enabled.
+      gardener_extension_shoot_cert_service_precheck_nameservers:
+        type: list
+        elements: str
+        description: Nameservers used for DNS prechecks of the shoot-cert-service extension.
+      gardener_extension_shoot_cert_service_shoot_issuers_enabled:
+        type: bool
+        description: Whether custom issuers can be configured in shoots.
+      gardener_extension_shoot_dns_service_enabled:
+        type: bool
+        description: Whether the shoot-dns-service extension is registered.
+      gardener_extension_shoot_dns_service_helm_chart_tag:
+        type: str
+        description: Tag of the shoot-dns-service extension helm chart.
+      gardener_extension_admission_shoot_dns_service_helm_chart_application_tag:
+        type: str
+        description: Tag of the shoot-dns-service admission application helm chart.
+      gardener_extension_admission_shoot_dns_service_helm_chart_runtime_tag:
+        type: str
+        description: Tag of the shoot-dns-service admission runtime helm chart.
+      gardener_shoot_dns_service_image_vector_overwrite:
+        type: list
+        description: Image vector overwrite for the shoot-dns-service extension.
+      gardener_shoot_dns_service_dns_controller_manager_image_name:
+        type: str
+        description: Image name override of the dns-controller-manager.
+      gardener_shoot_dns_service_dns_controller_manager_image_tag:
+        type: str
+        description: Image tag override of the dns-controller-manager.
+      gardener_shoot_dns_service_dns_provider_replication:
+        type: bool
+        description: Whether DNS provider replication is enabled in the shoot-dns-service extension.
+      gardener_extension_dns_external_controller_registration_url:
+        type: str
+        description: URL of an external dns controller registration to include.

--- a/control-plane/roles/gardener-gardenlet/meta/argument_specs.yaml
+++ b/control-plane/roles/gardener-gardenlet/meta/argument_specs.yaml
@@ -1,0 +1,31 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys gardenlets into the garden
+    options:
+      gardener_gardenlet_garden_name:
+        type: str
+        description: Name of the garden to deploy the gardenlets to.
+      gardener_gardenlet_helm_chart_tag:
+        type: str
+        description: Tag of the gardenlet helm chart. Derived from the gardenlet image tag of the release vector by default.
+      gardener_gardenlet_default_dns_domain:
+        type: str
+        required: true
+        description: The default DNS domain used for the seed DNS entries.
+      gardener_gardenlet_default_dns_provider:
+        type: str
+        required: true
+        description: The default DNS provider used for the seed DNS entries.
+      gardener_gardenlet_default_dns_credentials:
+        type: str
+        required: true
+        no_log: true
+        description: The credentials for the default DNS provider.
+      gardener_gardenlets:
+        type: list
+        elements: dict
+        description: The gardenlets to deploy.
+      gardener_gardenlet_defaults:
+        type: dict
+        description: Default configuration merged into every gardenlet entry.

--- a/control-plane/roles/gardener-logging/meta/argument_specs.yaml
+++ b/control-plane/roles/gardener-logging/meta/argument_specs.yaml
@@ -1,0 +1,59 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys Alloy (or deprecated Promtail) for Gardener seed and garden cluster logging
+    options:
+      gardener_logging_namespace:
+        type: str
+        description: The namespace to deploy the logging components to.
+      gardener_logging_garden_name:
+        type: str
+        description: Name of the garden.
+      gardener_logging_deploy_to_garden_cluster:
+        type: bool
+        description: Whether to deploy Alloy to the garden cluster.
+      gardener_logging_shooted_seeds:
+        type: list
+        description: The shooted seeds to deploy the logging components to.
+      gardener_logging_alloy_enabled:
+        type: bool
+        description: Whether to deploy Alloy.
+      gardener_logging_alloy_chart_version:
+        type: str
+        description: Version of the alloy helm chart. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      gardener_logging_alloy_chart_repo:
+        type: str
+        description: Repository URL of the alloy helm chart. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      gardener_logging_ingress_dns:
+        type: str
+        description: Ingress DNS name of loki.
+      gardener_logging_ingress_loki_basic_auth_user:
+        type: str
+        description: Basic auth user of the loki ingress.
+      gardener_logging_ingress_loki_basic_auth_password:
+        type: str
+        no_log: true
+        description: Basic auth password of the loki ingress.
+      gardener_logging_alloy_loki_write_endpoints:
+        type: list
+        elements: dict
+        description: Loki push endpoints for Alloy. Each entry supports url, remote_timeout and basic_auth (username, password).
+      gardener_logging_alloy_prometheus_write_endpoints:
+        type: list
+        elements: dict
+        description: Prometheus remote_write endpoints for Alloy self-metrics.
+      gardener_logging_alloy_prometheus_wal_truncate_frequency:
+        type: str
+        description: How often the Alloy remote_write WAL is compacted.
+      gardener_logging_alloy_prometheus_wal_max_keepalive_time:
+        type: str
+        description: Maximum age of undelivered WAL samples before they are dropped.
+      gardener_logging_promtail_enabled:
+        type: bool
+        description: Whether to deploy Promtail (deprecated). Requires gardener_logging_promtail_chart_version and gardener_logging_promtail_chart_repo when enabled.
+      gardener_logging_promtail_chart_version:
+        type: str
+        description: Version of the promtail helm chart. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      gardener_logging_promtail_chart_repo:
+        type: str
+        description: Repository URL of the promtail helm chart. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.

--- a/control-plane/roles/gardener-managed-seeds/meta/argument_specs.yaml
+++ b/control-plane/roles/gardener-managed-seeds/meta/argument_specs.yaml
@@ -1,0 +1,22 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys managed seeds into the garden
+    options:
+      gardener_managed_seeds_garden_name:
+        type: str
+        description: Name of the garden to deploy the managed seeds to.
+      gardener_managed_seed_default_dns_provider:
+        type: str
+        description: The default DNS provider used for the seed DNS entries.
+      gardener_managed_seed_default_dns_domain:
+        type: str
+        required: true
+        description: The default DNS domain used for the internal seed DNS entries.
+      gardener_managed_seeds:
+        type: list
+        elements: dict
+        description: The managed seeds to deploy.
+      gardener_managed_seed_defaults:
+        type: dict
+        description: Default configuration merged into every managed seed entry.

--- a/control-plane/roles/gardener-monitoring-certs/meta/argument_specs.yaml
+++ b/control-plane/roles/gardener-monitoring-certs/meta/argument_specs.yaml
@@ -1,0 +1,18 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys ingress certificates for Gardener seed monitoring
+    options:
+      gardener_monitoring_certs_garden_name:
+        type: str
+        description: Name of the garden.
+      gardener_monitoring_certs_certificate_cluster_issuer:
+        type: str
+        description: Name of the cert-manager ClusterIssuer used for issuing the seed ingress certificate.
+      gardener_monitoring_certs_ingress_domain:
+        type: str
+        description: The ingress domain for which the wildcard certificate is issued.
+      gardener_monitoring_certs_shooted_seeds:
+        type: list
+        elements: dict
+        description: The shooted seeds (name, ingress_domain) to distribute the certificates to.

--- a/control-plane/roles/gardener-operator/meta/argument_specs.yaml
+++ b/control-plane/roles/gardener-operator/meta/argument_specs.yaml
@@ -1,0 +1,96 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys the gardener-operator and the virtual garden
+    options:
+      gardener_operator_garden_name:
+        type: str
+        description: Name of the garden resource.
+      gardener_operator_repo_url:
+        type: str
+        description: URL of the gardener git repository used for applying the operator CRDs.
+      gardener_operator_repo_ref:
+        type: str
+        description: Git reference of the gardener repository.
+      gardener_operator_runtime_cluster_provider:
+        type: str
+        description: The provider of the runtime cluster.
+      gardener_operator_backup_infrastructure:
+        type: dict
+        description: Backup infrastructure configuration for the virtual garden etcd (provider gcp or S3). Mandatory, must not be none.
+      gardener_operator_backup_infrastructure_secret:
+        type: dict
+        no_log: true
+        description: Secret data for the backup infrastructure.
+      gardener_operator_dns_providers:
+        type: list
+        elements: dict
+        description: DNS providers configured in the garden resource.
+      gardener_operator_high_availability_control_plane:
+        type: bool
+        description: Whether the virtual garden control plane is deployed highly available.
+      gardener_operator_image_vector_overwrite:
+        type: raw
+        description: Image vector overwrite for the gardener components.
+      gardener_operator_component_image_vector_overwrite:
+        type: raw
+        description: Component image vector overwrite for the gardener components.
+      gardener_operator_helm_chart_tag:
+        type: str
+        description: Tag of the gardener-operator helm chart. Derived from the operator image tag of the release vector by default.
+      gardener_operator_image_name:
+        type: str
+        description: Image name of the gardener-operator. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      gardener_operator_image_tag:
+        type: str
+        description: Image tag of the gardener-operator. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      gardener_operator_shoot_admin_kubeconfig_max_expiration:
+        type: str
+        description: Maximum expiration of shoot admin kubeconfigs.
+      gardener_operator_dashboard_enabled:
+        type: bool
+        description: Whether the gardener dashboard is deployed.
+      gardener_operator_dashboard_oidc_session_lifetime:
+        type: str
+        description: OIDC session lifetime of the gardener dashboard.
+      gardener_operator_dashboard_oidc_additional_scopes:
+        type: list
+        elements: str
+        description: Additional OIDC scopes of the gardener dashboard.
+      gardener_operator_dashboard_oidc_client_id:
+        type: str
+        description: OIDC client id of the gardener dashboard.
+      gardener_operator_dashboard_oidc_client_id_public:
+        type: str
+        description: Public OIDC client id of the gardener dashboard.
+      gardener_operator_dashboard_oidc_client_secret:
+        type: str
+        no_log: true
+        description: OIDC client secret of the gardener dashboard.
+      gardener_operator_dashboard_log_level:
+        type: str
+        description: Log level of the gardener dashboard.
+      gardener_operator_dashboard_ingress_enabled:
+        type: bool
+        description: Whether to create an ingress for the gardener dashboard.
+      gardener_operator_wildcard_ingress_certificate_cluster_issuer:
+        type: str
+        description: Name of the cert-manager ClusterIssuer used for the wildcard ingress certificate.
+      gardener_operator_dashboard_config_frontend:
+        type: dict
+        description: Frontend configuration of the gardener dashboard.
+      gardener_operator_dashboard_config_assets:
+        type: dict
+        description: Asset configuration (e.g. logos) of the gardener dashboard.
+      gardener_operator_virtual_garden_public_dns:
+        type: str
+        description: Public DNS name of the virtual garden kube-apiserver.
+      gardener_operator_virtual_garden_etcd_storage_class:
+        type: str
+        description: Storage class of the virtual garden etcd.
+      gardener_operator_expose_virtual_garden_through_ingress_nginx:
+        type: bool
+        description: Whether the virtual garden kube-apiserver is exposed through ingress-nginx.
+      gardener_operator_virtual_garden_api_server_structured_authentication:
+        type: dict
+        description: Structured authentication configuration for the virtual garden kube-apiserver.

--- a/control-plane/roles/gardener-partition-proxy/meta/argument_specs.yaml
+++ b/control-plane/roles/gardener-partition-proxy/meta/argument_specs.yaml
@@ -1,0 +1,34 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys a proxy in shooted seeds for reaching the metal-api from partitions
+    options:
+      gardener_partition_proxy_garden_name:
+        type: str
+        description: Name of the garden.
+      gardener_partition_proxy_metal_api_url:
+        type: str
+        description: The metal-api URL that the proxy forwards to.
+      gardener_partition_proxy_metal_api_edit_hmac:
+        type: str
+        no_log: true
+        description: The metal-api edit HMAC used for looking up partitions.
+      gardener_partition_proxy_dns_credentials:
+        type: str
+        no_log: true
+        description: Credentials for the DNS provider of the proxy DNS entry.
+      gardener_partition_proxy_dns_provider:
+        type: str
+        description: The DNS provider type of the proxy DNS entry.
+      gardener_partition_proxy_ip_address:
+        type: str
+        description: The load balancer IP address of the proxy service.
+      gardener_partition_proxy_image_name:
+        type: str
+        description: Image name of the proxy.
+      gardener_partition_proxy_image_tag:
+        type: str
+        description: Image tag of the proxy.
+      gardener_partition_proxy_shooted_seeds:
+        type: list
+        description: The shooted seeds to deploy the proxy to.

--- a/control-plane/roles/gardener-projects/meta/argument_specs.yaml
+++ b/control-plane/roles/gardener-projects/meta/argument_specs.yaml
@@ -1,0 +1,15 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys Gardener projects into the virtual garden
+    options:
+      gardener_projects_garden_name:
+        type: str
+        description: Name of the garden to deploy the projects to.
+      gardener_projects:
+        type: list
+        elements: dict
+        description: The Gardener projects to deploy (name, description, members, protected_toleration).
+      gardener_project_defaults:
+        type: dict
+        description: Default configuration merged into every project entry.

--- a/control-plane/roles/gardener-shoots/meta/argument_specs.yaml
+++ b/control-plane/roles/gardener-shoots/meta/argument_specs.yaml
@@ -1,0 +1,28 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys shoot clusters into the garden
+    options:
+      gardener_shoots_garden_name:
+        type: str
+        description: Name of the garden to deploy the shoots to.
+      gardener_shoot_rollout_wait_enabled:
+        type: bool
+        description: Whether to wait for shoot reconciliation to succeed.
+      gardener_shoot_rollout_wait_retries:
+        type: int
+        description: Amount of retries when waiting for shoot reconciliation.
+      gardener_shoot_rollout_wait_delay:
+        type: int
+        description: Delay in seconds between retries when waiting for shoot reconciliation.
+      gardener_shoot_default_metal_api_hmac:
+        type: str
+        no_log: true
+        description: The default metal-api HMAC used for the shoot infrastructure secrets.
+      gardener_shoots:
+        type: list
+        elements: dict
+        description: The shoot clusters to deploy.
+      gardener_shoot_defaults:
+        type: dict
+        description: Default configuration merged into every shoot entry.

--- a/control-plane/roles/gardener-virtual-garden-access/meta/argument_specs.yaml
+++ b/control-plane/roles/gardener-virtual-garden-access/meta/argument_specs.yaml
@@ -1,0 +1,15 @@
+---
+argument_specs:
+  main:
+    short_description: Creates access resources for the virtual garden and deploys cluster role bindings
+    options:
+      gardener_virtual_garden_access_garden_name:
+        type: str
+        description: Name of the garden to create the access resources for.
+      gardener_virtual_garden_access_expiration:
+        type: str
+        description: Token expiration duration for the virtual garden access service account.
+      gardener_virtual_garden_access_cluster_role_bindings:
+        type: list
+        elements: dict
+        description: Cluster role bindings deployed to the virtual garden.

--- a/control-plane/roles/headscale/meta/argument_specs.yaml
+++ b/control-plane/roles/headscale/meta/argument_specs.yaml
@@ -1,0 +1,145 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys headscale with a postgres database for machine VPN access
+    options:
+      headscale_image_name:
+        type: str
+        description: Image name of headscale. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      headscale_image_tag:
+        type: str
+        description: Image tag of headscale. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      headscale_namespace:
+        type: str
+        description: The namespace to deploy headscale to.
+      headscale_ingress_dns:
+        type: str
+        description: Ingress DNS name of headscale.
+      headscale_tls:
+        type: bool
+        description: Whether TLS is enabled on the headscale ingress.
+      headscale_ingress_enabled:
+        type: bool
+        description: Whether to create an ingress for headscale.
+      headscale_ingress_annotations:
+        type: dict
+        description: Additional annotations for the headscale ingress.
+      headscale_resources:
+        type: dict
+        description: Resource requests and limits for the headscale container.
+      headscale_noise_private_key:
+        type: str
+        required: true
+        no_log: true
+        description: The headscale noise protocol private key.
+      headscale_api_key_expiration:
+        type: str
+        description: Expiration duration of the created headscale API key.
+      headscale_ipv4_prefix:
+        type: str
+        description: IPv4 prefix assigned to VPN clients.
+      headscale_ipv6_prefix:
+        type: str
+        description: IPv6 prefix assigned to VPN clients.
+      headscale_httproute_enabled:
+        type: bool
+        description: Whether to expose headscale through a GatewayAPI HTTPRoute instead of an ingress.
+      headscale_httproute_hostnames:
+        type: list
+        elements: str
+        description: Hostnames for the headscale HTTPRoute.
+      headscale_httproute_parent_refs:
+        type: list
+        elements: dict
+        description: Parent references for the headscale HTTPRoute.
+      headscale_httproute_https_redirect:
+        type: dict
+        description: HTTPS redirect configuration for the headscale HTTPRoute.
+      headscale_db_name:
+        type: str
+        description: Name of the headscale db deployment.
+      headscale_db_image_name:
+        type: str
+        description: Image name of the headscale db. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      headscale_db_image_tag:
+        type: str
+        description: Image tag of the headscale db. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      headscale_db_storage_size:
+        type: str
+        description: Size of the headscale db persistent volume.
+      headscale_db_storage_class:
+        type: str
+        description: Storage class of the headscale db persistent volume.
+      headscale_db_db:
+        type: str
+        description: Name of the headscale database to create.
+      headscale_db_user:
+        type: str
+        description: User of the headscale database.
+      headscale_db_password:
+        type: str
+        no_log: true
+        description: Password of the headscale database.
+      headscale_db_max_connections:
+        type: raw
+        description: Maximum amount of database connections.
+      headscale_db_backup_restore_sidecar_image_name:
+        type: str
+        description: Image name of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      headscale_db_backup_restore_sidecar_image_tag:
+        type: str
+        description: Image tag of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      headscale_db_backup_restore_sidecar_provider:
+        type: str
+        description: Backup provider used by the backup-restore-sidecar (local, gcp or s3).
+      headscale_db_backup_restore_sidecar_backup_cron_schedule:
+        type: str
+        description: Cron schedule for creating backups.
+      headscale_db_backup_restore_sidecar_log_level:
+        type: str
+        description: Log level of the backup-restore-sidecar.
+      headscale_db_backup_restore_sidecar_object_prefix:
+        type: str
+        description: Object prefix used for backups in the object store.
+      headscale_db_backup_restore_sidecar_encryption_key:
+        type: str
+        no_log: true
+        description: Encryption key (32 characters) for encrypting backups.
+      headscale_db_backup_restore_sidecar_gcp_bucket_name:
+        type: str
+        description: GCP bucket name for storing backups.
+      headscale_db_backup_restore_sidecar_gcp_backup_location:
+        type: str
+        description: GCP bucket location for storing backups.
+      headscale_db_backup_restore_sidecar_gcp_project_id:
+        type: str
+        description: GCP project id of the backup bucket.
+      headscale_db_backup_restore_sidecar_gcp_serviceaccount_json:
+        type: str
+        no_log: true
+        description: GCP service account JSON used for accessing the backup bucket.
+      headscale_db_backup_restore_sidecar_s3_bucket_name:
+        type: str
+        description: S3 bucket name for storing backups.
+      headscale_db_backup_restore_sidecar_s3_region:
+        type: str
+        description: S3 region of the backup bucket.
+      headscale_db_backup_restore_sidecar_s3_endpoint:
+        type: str
+        description: S3 endpoint of the backup bucket.
+      headscale_db_backup_restore_sidecar_s3_access_key:
+        type: str
+        description: S3 access key for the backup bucket.
+      headscale_db_backup_restore_sidecar_s3_secret_key:
+        type: str
+        no_log: true
+        description: S3 secret key for the backup bucket.
+      headscale_db_backup_restore_sidecar_s3_insecure_skip_verify:
+        type: raw
+        description: Whether to skip TLS certificate verification for the S3 endpoint.
+      headscale_db_backup_restore_sidecar_s3_trusted_ca_cert:
+        type: str
+        description: Trusted CA certificate for the S3 endpoint.
+      headscale_db_resources:
+        type: dict
+        description: Resource requests and limits for the headscale db container.

--- a/control-plane/roles/ipam-db/meta/argument_specs.yaml
+++ b/control-plane/roles/ipam-db/meta/argument_specs.yaml
@@ -1,0 +1,118 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys the ipam database via the postgres-backup-restore role
+    options:
+      ipam_db_name:
+        type: str
+        description: Name of the the ipam db deployment.
+      ipam_db_namespace:
+        type: str
+        description: The namespace to deploy the ipam db to.
+      ipam_db_image_pull_policy:
+        type: str
+        description: Image pull policy for the the ipam db container.
+      ipam_db_storage_size:
+        type: str
+        description: Size of the persistent volume.
+      ipam_db_storage_class:
+        type: str
+        description: Storage class of the persistent volume.
+      ipam_db_db:
+        type: str
+        description: Name of the database to create.
+      ipam_db_user:
+        type: str
+        description: User of the the ipam db database.
+      ipam_db_password:
+        type: str
+        no_log: true
+        description: Password of the the ipam db database.
+      ipam_db_max_connections:
+        type: raw
+        description: Maximum amount of database connections.
+      ipam_db_backup_restore_sidecar_image_pull_policy:
+        type: str
+        description: Image pull policy for the backup-restore-sidecar container.
+      ipam_db_backup_restore_sidecar_provider:
+        type: str
+        description: Backup provider used by the backup-restore-sidecar (local, gcp or s3).
+      ipam_db_backup_restore_sidecar_backup_cron_schedule:
+        type: str
+        description: Cron schedule for creating backups.
+      ipam_db_backup_restore_sidecar_log_level:
+        type: str
+        description: Log level of the backup-restore-sidecar.
+      ipam_db_backup_restore_sidecar_object_prefix:
+        type: str
+        description: Object prefix used for backups in the object store.
+      ipam_db_backup_restore_sidecar_object_max_keep:
+        type: raw
+        description: Maximum amount of backup objects to keep.
+      ipam_db_backup_restore_sidecar_object_days_max_keep:
+        type: raw
+        description: Maximum age in days of backup objects to keep.
+      ipam_db_backup_restore_sidecar_s3_request_checksum_calculation:
+        type: str
+        description: S3 request checksum calculation setting (e.g. when_required for non-AWS S3 endpoints).
+      ipam_db_backup_restore_sidecar_encryption_key:
+        type: str
+        no_log: true
+        description: Encryption key (32 characters) for encrypting backups.
+      ipam_db_backup_restore_sidecar_gcp_bucket_name:
+        type: str
+        description: GCP bucket name for storing backups.
+      ipam_db_backup_restore_sidecar_gcp_backup_location:
+        type: str
+        description: GCP bucket location for storing backups.
+      ipam_db_backup_restore_sidecar_gcp_project_id:
+        type: str
+        description: GCP project id of the backup bucket.
+      ipam_db_backup_restore_sidecar_gcp_serviceaccount_json:
+        type: str
+        no_log: true
+        description: GCP service account JSON used for accessing the backup bucket.
+      ipam_db_backup_restore_sidecar_s3_bucket_name:
+        type: str
+        description: S3 bucket name for storing backups.
+      ipam_db_backup_restore_sidecar_s3_region:
+        type: str
+        description: S3 region of the backup bucket.
+      ipam_db_backup_restore_sidecar_s3_endpoint:
+        type: str
+        description: S3 endpoint of the backup bucket.
+      ipam_db_backup_restore_sidecar_s3_access_key:
+        type: str
+        description: S3 access key for the backup bucket.
+      ipam_db_backup_restore_sidecar_s3_secret_key:
+        type: str
+        no_log: true
+        description: S3 secret key for the backup bucket.
+      ipam_db_backup_restore_sidecar_s3_insecure_skip_verify:
+        type: raw
+        description: Whether to skip TLS certificate verification for the S3 endpoint.
+      ipam_db_backup_restore_sidecar_s3_trusted_ca_cert:
+        type: str
+        description: Trusted CA certificate for the S3 endpoint.
+      ipam_db_resources:
+        type: dict
+        description: Resource requests and limits for the the ipam db container.
+      ipam_db_registry_auth_enabled:
+        type: raw
+        description: Whether to deploy an image pull secret for the registry.
+      ipam_db_registry_auth:
+        type: dict
+        no_log: true
+        description: Docker auth configuration for the image pull secret.
+      ipam_db_image_name:
+        type: str
+        description: Image name of the ipam db. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      ipam_db_image_tag:
+        type: str
+        description: Image tag of the ipam db. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      ipam_db_backup_restore_sidecar_image_name:
+        type: str
+        description: Image name of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      ipam_db_backup_restore_sidecar_image_tag:
+        type: str
+        description: Image tag of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.

--- a/control-plane/roles/isolated-clusters/meta/argument_specs.yaml
+++ b/control-plane/roles/isolated-clusters/meta/argument_specs.yaml
@@ -1,0 +1,114 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys services (NTP, DNS, registry, ingress) for isolated partition clusters
+    options:
+      isolated_clusters_virtual_garden_kubeconfig:
+        type: str
+        no_log: true
+        description: Kubeconfig content for accessing the virtual garden. Read from the garden-access secret by default.
+      isolated_clusters_group_label:
+        type: str
+        description: Label value used for grouping the isolated cluster services.
+      isolated_clusters_partition_services_cluster:
+        type: list
+        description: The clusters to install the partition services into.
+      isolated_clusters_ntp_image_name:
+        type: str
+        description: Image name of the chrony NTP service.
+      isolated_clusters_ntp_image_tag:
+        type: str
+        required: true
+        description: Image tag of the chrony NTP service.
+      isolated_clusters_ntp_namespace:
+        type: str
+        description: The namespace to deploy the NTP service to.
+      isolated_clusters_dns_image_name:
+        type: str
+        description: Image name of the CoreDNS DNS service.
+      isolated_clusters_dns_image_tag:
+        type: str
+        required: true
+        description: Image tag of the CoreDNS DNS service.
+      isolated_clusters_dns_namespace:
+        type: str
+        description: The namespace to deploy the DNS service to.
+      isolated_clusters_ingress_controller_enabled:
+        type: bool
+        description: Whether to deploy the ingress controller.
+      isolated_clusters_ingress_controller_namespace:
+        type: str
+        description: The namespace to deploy the ingress controller to.
+      isolated_clusters_ingress_controller_chart_version:
+        type: str
+        description: Version of the ingress-nginx helm chart. Required when the ingress controller is enabled.
+      isolated_clusters_ingress_controller_chroot:
+        type: bool
+        description: Whether the ingress controller runs in a chroot.
+      isolated_clusters_ingress_controller_replicas:
+        type: int
+        description: Amount of ingress controller replicas.
+      isolated_clusters_ingress_controller_load_balancer_ip:
+        type: str
+        description: Load balancer IP of the ingress controller service. Required when the ingress controller is enabled.
+      isolated_clusters_ingress_controller_load_balancer_source_ranges:
+        type: list
+        description: Load balancer source ranges of the ingress controller service. Required when the ingress controller is enabled.
+      isolated_clusters_envoy_gateway_enabled:
+        type: bool
+        description: Whether to deploy the envoy gateway.
+      isolated_clusters_envoy_gateway_namespace:
+        type: str
+        description: The namespace to deploy the envoy gateway to.
+      isolated_clusters_envoy_gateway_chart_version:
+        type: str
+        description: Version of the envoy gateway helm chart. Required when the envoy gateway is enabled.
+      isolated_clusters_envoy_gateway_replicas:
+        type: int
+        description: Amount of envoy gateway replicas.
+      isolated_clusters_envoy_gateway_load_balancer_ip:
+        type: str
+        description: Load balancer IP of the envoy gateway service.
+      isolated_clusters_envoy_gateway_load_balancer_source_ranges:
+        type: list
+        description: Load balancer source ranges of the envoy gateway service.
+      isolated_clusters_envoy_gateway_registry_tls_secret_name:
+        type: str
+        description: Name of the TLS secret used for the registry route of the envoy gateway.
+      isolated_clusters_envoy_gateway_udp_session_idle_timeout:
+        type: str
+        description: UDP session idle timeout of the envoy gateway.
+      isolated_clusters_registry_image_name:
+        type: str
+        description: Image name of the registry.
+      isolated_clusters_registry_image_tag:
+        type: str
+        required: true
+        description: Image tag of the registry.
+      isolated_clusters_registry_namespace:
+        type: str
+        description: The namespace to deploy the registry to.
+      isolated_clusters_registry_oci_mirror_image_name:
+        type: str
+        description: Image name of the oci-mirror. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      isolated_clusters_registry_oci_mirror_image_tag:
+        type: str
+        description: Image tag of the oci-mirror. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      isolated_clusters_registry_oci_mirror_config:
+        type: dict
+        description: Configuration of the oci-mirror (registries and images to mirror).
+      isolated_clusters_registry_storage_size:
+        type: str
+        description: Size of the registry persistent volume.
+      isolated_clusters_registry_storage_class_name:
+        type: str
+        description: Storage class of the registry persistent volume.
+      isolated_clusters_registry_fqdn:
+        type: str
+        description: FQDN under which the registry is reachable through the envoy gateway. Required when the envoy gateway is enabled.
+      isolated_clusters_registry_ingress_fqdn:
+        type: str
+        description: FQDN under which the registry is reachable through the ingress controller. Required when the ingress controller is enabled.
+      isolated_clusters_registry_ingress_annotations:
+        type: dict
+        description: Additional annotations for the registry ingress.

--- a/control-plane/roles/logging-common/meta/argument_specs.yaml
+++ b/control-plane/roles/logging-common/meta/argument_specs.yaml
@@ -1,0 +1,40 @@
+---
+argument_specs:
+  deploy-alloy:
+    short_description: Shared tasks for deploying Grafana Alloy via helm chart
+    options:
+      logging_common_alloy_namespace:
+        type: str
+        description: The namespace to deploy Alloy to.
+      logging_common_alloy_chart_version:
+        type: str
+        description: Version of the alloy helm chart. Usually passed by the consuming role.
+      logging_common_alloy_chart_repo:
+        type: str
+        description: Repository URL of the alloy helm chart. Usually passed by the consuming role.
+      logging_common_alloy_service_monitor_enabled:
+        type: bool
+        description: Whether to create a ServiceMonitor for Alloy self-metrics scraping. Never enable in Gardener seed clusters.
+      logging_common_alloy_loki_write_endpoints:
+        type: list
+        elements: dict
+        description: Loki push endpoints. Each entry supports url, remote_timeout and basic_auth (username, password).
+      logging_common_alloy_cluster_label:
+        type: str
+        description: Value for the cluster label attached to all log and metric streams. Must not be empty.
+      logging_common_alloy_prometheus_write_endpoints:
+        type: list
+        elements: dict
+        description: Prometheus remote_write endpoints for Alloy self-metrics.
+      logging_common_alloy_prometheus_wal_truncate_frequency:
+        type: str
+        description: How often the Alloy remote_write WAL is compacted.
+      logging_common_alloy_prometheus_wal_max_keepalive_time:
+        type: str
+        description: Maximum age of undelivered WAL samples before they are dropped.
+      logging_common_alloy_config_raw:
+        type: str
+        description: Full Alloy River config override. When set, bypasses the structured vars and the template.
+      logging_common_alloy_kubeconfig:
+        type: str
+        description: Path to a kubeconfig used for deploying the alloy helm chart to a different cluster.

--- a/control-plane/roles/logging/meta/argument_specs.yaml
+++ b/control-plane/roles/logging/meta/argument_specs.yaml
@@ -1,0 +1,81 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys Loki and Alloy (or deprecated Promtail) for control plane logging
+    options:
+      logging_namespace:
+        type: str
+        description: The namespace to deploy the logging stack to.
+      logging_chart_version:
+        type: str
+        description: Version of the loki helm chart. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      logging_chart_repo:
+        type: str
+        description: Repository URL of the loki helm chart. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      logging_alloy_enabled:
+        type: bool
+        description: Whether to deploy Alloy.
+      logging_alloy_chart_version:
+        type: str
+        description: Version of the alloy helm chart. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      logging_alloy_chart_repo:
+        type: str
+        description: Repository URL of the alloy helm chart. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      logging_alloy_loki_write_endpoints:
+        type: list
+        elements: dict
+        description: Loki push endpoints for Alloy. Each entry supports url, remote_timeout and basic_auth (username, password).
+      logging_alloy_cluster_label:
+        type: str
+        description: Value for the cluster label attached to all log and metric streams.
+      logging_alloy_service_monitor_enabled:
+        type: bool
+        description: Whether to create a ServiceMonitor for Alloy self-metrics scraping. Requires the monitoring role to be deployed.
+      logging_alloy_prometheus_write_endpoints:
+        type: list
+        elements: dict
+        description: Prometheus remote_write endpoints for Alloy self-metrics.
+      logging_alloy_prometheus_wal_truncate_frequency:
+        type: str
+        description: How often the Alloy remote_write WAL is compacted.
+      logging_alloy_prometheus_wal_max_keepalive_time:
+        type: str
+        description: Maximum age of undelivered WAL samples before they are dropped.
+      logging_alloy_config_raw:
+        type: str
+        description: Full Alloy River config override. When set, bypasses all structured vars and the template.
+      logging_promtail_enabled:
+        type: bool
+        description: Whether to deploy Promtail (deprecated). When false, any existing Promtail release is uninstalled.
+      logging_promtail_chart_version:
+        type: str
+        description: Version of the promtail helm chart. Required when logging_promtail_enabled is true. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      logging_promtail_chart_repo:
+        type: str
+        description: Repository URL of the promtail helm chart. Required when logging_promtail_enabled is true. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      logging_ingress_dns:
+        type: str
+        description: Ingress DNS name of loki.
+      logging_ingress_loki_tls:
+        type: bool
+        description: Whether TLS is enabled on the loki ingress.
+      logging_ingress_loki_basic_auth_user:
+        type: str
+        description: Basic auth user of the loki ingress.
+      logging_ingress_loki_basic_auth_password:
+        type: str
+        no_log: true
+        description: Basic auth password of the loki ingress.
+      logging_ingress_loki_basic_auth_password_salt:
+        type: str
+        no_log: true
+        description: Salt used for generating the htpasswd entry of the loki ingress.
+      logging_ingress_annotations:
+        type: dict
+        description: Additional annotations for the loki ingress.
+      logging_loki_enabled:
+        type: bool
+        description: Whether to deploy loki.
+      logging_loki_size:
+        type: str
+        description: Size of the loki persistent volume.

--- a/control-plane/roles/masterdata-db/meta/argument_specs.yaml
+++ b/control-plane/roles/masterdata-db/meta/argument_specs.yaml
@@ -1,0 +1,118 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys the masterdata database via the postgres-backup-restore role
+    options:
+      masterdata_db_name:
+        type: str
+        description: Name of the the masterdata db deployment.
+      masterdata_db_namespace:
+        type: str
+        description: The namespace to deploy the masterdata db to.
+      masterdata_db_image_pull_policy:
+        type: str
+        description: Image pull policy for the the masterdata db container.
+      masterdata_db_storage_size:
+        type: str
+        description: Size of the persistent volume.
+      masterdata_db_storage_class:
+        type: str
+        description: Storage class of the persistent volume.
+      masterdata_db_db:
+        type: str
+        description: Name of the database to create.
+      masterdata_db_user:
+        type: str
+        description: User of the the masterdata db database.
+      masterdata_db_password:
+        type: str
+        no_log: true
+        description: Password of the the masterdata db database.
+      masterdata_db_max_connections:
+        type: raw
+        description: Maximum amount of database connections.
+      masterdata_db_backup_restore_sidecar_image_pull_policy:
+        type: str
+        description: Image pull policy for the backup-restore-sidecar container.
+      masterdata_db_backup_restore_sidecar_provider:
+        type: str
+        description: Backup provider used by the backup-restore-sidecar (local, gcp or s3).
+      masterdata_db_backup_restore_sidecar_backup_cron_schedule:
+        type: str
+        description: Cron schedule for creating backups.
+      masterdata_db_backup_restore_sidecar_log_level:
+        type: str
+        description: Log level of the backup-restore-sidecar.
+      masterdata_db_backup_restore_sidecar_object_prefix:
+        type: str
+        description: Object prefix used for backups in the object store.
+      masterdata_db_backup_restore_sidecar_object_max_keep:
+        type: raw
+        description: Maximum amount of backup objects to keep.
+      masterdata_db_backup_restore_sidecar_object_days_max_keep:
+        type: raw
+        description: Maximum age in days of backup objects to keep.
+      masterdata_db_backup_restore_sidecar_s3_request_checksum_calculation:
+        type: str
+        description: S3 request checksum calculation setting (e.g. when_required for non-AWS S3 endpoints).
+      masterdata_db_backup_restore_sidecar_encryption_key:
+        type: str
+        no_log: true
+        description: Encryption key (32 characters) for encrypting backups.
+      masterdata_db_backup_restore_sidecar_gcp_bucket_name:
+        type: str
+        description: GCP bucket name for storing backups.
+      masterdata_db_backup_restore_sidecar_gcp_backup_location:
+        type: str
+        description: GCP bucket location for storing backups.
+      masterdata_db_backup_restore_sidecar_gcp_project_id:
+        type: str
+        description: GCP project id of the backup bucket.
+      masterdata_db_backup_restore_sidecar_gcp_serviceaccount_json:
+        type: str
+        no_log: true
+        description: GCP service account JSON used for accessing the backup bucket.
+      masterdata_db_backup_restore_sidecar_s3_bucket_name:
+        type: str
+        description: S3 bucket name for storing backups.
+      masterdata_db_backup_restore_sidecar_s3_region:
+        type: str
+        description: S3 region of the backup bucket.
+      masterdata_db_backup_restore_sidecar_s3_endpoint:
+        type: str
+        description: S3 endpoint of the backup bucket.
+      masterdata_db_backup_restore_sidecar_s3_access_key:
+        type: str
+        description: S3 access key for the backup bucket.
+      masterdata_db_backup_restore_sidecar_s3_secret_key:
+        type: str
+        no_log: true
+        description: S3 secret key for the backup bucket.
+      masterdata_db_backup_restore_sidecar_s3_insecure_skip_verify:
+        type: raw
+        description: Whether to skip TLS certificate verification for the S3 endpoint.
+      masterdata_db_backup_restore_sidecar_s3_trusted_ca_cert:
+        type: str
+        description: Trusted CA certificate for the S3 endpoint.
+      masterdata_db_resources:
+        type: dict
+        description: Resource requests and limits for the the masterdata db container.
+      masterdata_db_registry_auth_enabled:
+        type: raw
+        description: Whether to deploy an image pull secret for the registry.
+      masterdata_db_registry_auth:
+        type: dict
+        no_log: true
+        description: Docker auth configuration for the image pull secret.
+      masterdata_db_image_name:
+        type: str
+        description: Image name of the masterdata db. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      masterdata_db_image_tag:
+        type: str
+        description: Image tag of the masterdata db. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      masterdata_db_backup_restore_sidecar_image_name:
+        type: str
+        description: Image name of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      masterdata_db_backup_restore_sidecar_image_tag:
+        type: str
+        description: Image tag of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.

--- a/control-plane/roles/metal-db/meta/argument_specs.yaml
+++ b/control-plane/roles/metal-db/meta/argument_specs.yaml
@@ -1,0 +1,112 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys the metal database (RethinkDB) via the rethinkdb-backup-restore role
+    options:
+      metal_db_name:
+        type: str
+        description: Name of the the metal db deployment.
+      metal_db_namespace:
+        type: str
+        description: The namespace to deploy the metal db to.
+      metal_db_image_pull_policy:
+        type: str
+        description: Image pull policy for the the metal db container.
+      metal_db_storage_size:
+        type: str
+        description: Size of the persistent volume.
+      metal_db_storage_class:
+        type: str
+        description: Storage class of the persistent volume.
+      metal_db_password:
+        type: str
+        no_log: true
+        description: Password of the the metal db database.
+      metal_db_backup_restore_sidecar_image_pull_policy:
+        type: str
+        description: Image pull policy for the backup-restore-sidecar container.
+      metal_db_backup_restore_sidecar_provider:
+        type: str
+        description: Backup provider used by the backup-restore-sidecar (local, gcp or s3).
+      metal_db_backup_restore_sidecar_backup_cron_schedule:
+        type: str
+        description: Cron schedule for creating backups.
+      metal_db_backup_restore_sidecar_log_level:
+        type: str
+        description: Log level of the backup-restore-sidecar.
+      metal_db_backup_restore_sidecar_object_max_keep:
+        type: raw
+        description: Maximum amount of backup objects to keep.
+      metal_db_backup_restore_sidecar_object_days_max_keep:
+        type: raw
+        description: Maximum age in days of backup objects to keep.
+      metal_db_backup_restore_sidecar_s3_request_checksum_calculation:
+        type: str
+        description: S3 request checksum calculation setting (e.g. when_required for non-AWS S3 endpoints).
+      metal_db_backup_restore_sidecar_encryption_key:
+        type: str
+        no_log: true
+        description: Encryption key (32 characters) for encrypting backups.
+      metal_db_backup_restore_sidecar_gcp_bucket_name:
+        type: str
+        description: GCP bucket name for storing backups.
+      metal_db_backup_restore_sidecar_gcp_backup_location:
+        type: str
+        description: GCP bucket location for storing backups.
+      metal_db_backup_restore_sidecar_gcp_project_id:
+        type: str
+        description: GCP project id of the backup bucket.
+      metal_db_backup_restore_sidecar_gcp_serviceaccount_json:
+        type: str
+        no_log: true
+        description: GCP service account JSON used for accessing the backup bucket.
+      metal_db_backup_restore_sidecar_s3_bucket_name:
+        type: str
+        description: S3 bucket name for storing backups.
+      metal_db_backup_restore_sidecar_s3_region:
+        type: str
+        description: S3 region of the backup bucket.
+      metal_db_backup_restore_sidecar_s3_endpoint:
+        type: str
+        description: S3 endpoint of the backup bucket.
+      metal_db_backup_restore_sidecar_s3_access_key:
+        type: str
+        description: S3 access key for the backup bucket.
+      metal_db_backup_restore_sidecar_s3_secret_key:
+        type: str
+        no_log: true
+        description: S3 secret key for the backup bucket.
+      metal_db_backup_restore_sidecar_s3_insecure_skip_verify:
+        type: raw
+        description: Whether to skip TLS certificate verification for the S3 endpoint.
+      metal_db_backup_restore_sidecar_s3_trusted_ca_cert:
+        type: str
+        description: Trusted CA certificate for the S3 endpoint.
+      metal_db_expose_frontend:
+        type: bool
+        description: Whether to expose the RethinkDB web frontend through an ingress.
+      metal_db_ingress_dns:
+        type: str
+        description: Ingress DNS name for the RethinkDB web frontend.
+      metal_db_resources:
+        type: dict
+        description: Resource requests and limits for the the metal db container.
+      metal_db_registry_auth_enabled:
+        type: raw
+        description: Whether to deploy an image pull secret for the registry.
+      metal_db_registry_auth:
+        type: dict
+        no_log: true
+        description: Docker auth configuration for the image pull secret.
+      metal_db_image_name:
+        type: str
+        description: Image name of the metal db. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_db_image_tag:
+        type: str
+        description: Image tag of the metal db. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_db_backup_restore_sidecar_image_name:
+        type: str
+        description: Image name of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_db_backup_restore_sidecar_image_tag:
+        type: str
+        description: Image tag of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.

--- a/control-plane/roles/metal-python/meta/argument_specs.yaml
+++ b/control-plane/roles/metal-python/meta/argument_specs.yaml
@@ -1,0 +1,17 @@
+---
+argument_specs:
+  main:
+    short_description: Installs the metal-python client library
+    options:
+      metal_python_version:
+        type: str
+        description: The metal-python version to install. Required unless metal_python_version_from_release_vector is true.
+      metal_python_version_from_release_vector:
+        type: bool
+        description: Derive the metal-python version from the metal-stack release vector.
+      metal_python_install_latest_on_version_error:
+        type: bool
+        description: Install the latest available client as fallback when the requested version is not available.
+      metal_python_install_from_git_repository:
+        type: bool
+        description: Install the client from the git repository instead of PyPI.

--- a/control-plane/roles/metal/meta/argument_specs.yaml
+++ b/control-plane/roles/metal/meta/argument_specs.yaml
@@ -1,0 +1,687 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys the metal control plane (metal-api, metal-apiserver, masterdata-api, tenant-apiserver, ipam, metal-console) via helm
+    options:
+      metal_check_api_available:
+        type: bool
+        description: Whether to wait for the metal-api health endpoint after deployment.
+      metal_check_api_health_endpoint:
+        type: str
+        description: The health endpoint URL that is probed after deployment.
+      metal_helm_chart:
+        type: str
+        description: OCI reference of the metal-control-plane helm chart. Required unless metal_helm_chart_local_path is set. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_helm_chart_tag:
+        type: str
+        description: Tag of the metal-control-plane helm chart. Required unless metal_helm_chart_local_path is set. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_helm_chart_local_path:
+        type: str
+        description: Local path to the metal-control-plane helm chart, used instead of the OCI chart when set.
+      metal_helm_chart_version:
+        type: str
+        description: Version of the local metal-control-plane helm chart. Only evaluated when metal_helm_chart_local_path is set.
+      metal_helm_chart_timeout:
+        type: str
+        description: Timeout for the helm deployment.
+      metal_set_resource_limits:
+        type: bool
+        description: Whether to set resource requests and limits on the control plane containers.
+      metal_log_level:
+        type: str
+        description: Log level of the metal control plane components.
+      metal_metalctl_image_pull_policy:
+        type: str
+        description: Image pull policy for the metalctl container.
+      metal_metalctl_image_name:
+        type: str
+        description: Image name of metalctl. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_metalctl_image_tag:
+        type: str
+        description: Image tag of metalctl. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_api_port:
+        type: int
+        description: Service port of the metal-api.
+      metal_apiserver_port:
+        type: int
+        description: Service port of the metal-apiserver.
+      metal_api_grpc_port:
+        type: int
+        description: gRPC port of the metal-api.
+      metal_api_metrics_port:
+        type: int
+        description: Metrics port of the metal-api.
+      metal_masterdata_api_port:
+        type: int
+        description: Service port of the masterdata-api.
+      metal_masterdata_api_metrics_port:
+        type: int
+        description: Metrics port of the masterdata-api.
+      metal_console_port:
+        type: int
+        description: Service port of the metal-console.
+      metal_apiserver_enabled:
+        type: bool
+        description: Whether to deploy the metal-apiserver (v2 API).
+      metal_apiserver_url:
+        type: str
+        description: The external URL of the metal-apiserver.
+      metal_apiserver_image_pull_policy:
+        type: str
+        description: Image pull policy for the metal-apiserver container.
+      metal_apiserver_image_name:
+        type: str
+        description: Image name of the metal-apiserver. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_apiserver_image_tag:
+        type: str
+        description: Image tag of the metal-apiserver. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_apiserver_db_addresses:
+        type: list
+        elements: str
+        description: Addresses of the metal-db instances used by the metal-apiserver.
+      metal_apiserver_db_password:
+        type: str
+        no_log: true
+        description: Password of the metal-db used by the metal-apiserver.
+      metal_apiserver_provider_tenant:
+        type: str
+        description: The provider tenant of the metal-apiserver.
+      metal_apiserver_redis_addr:
+        type: str
+        description: Address of the redis/valkey instance used by the metal-apiserver.
+      metal_apiserver_replicas:
+        type: int
+        description: Amount of metal-apiserver replicas.
+      metal_apiserver_hpa_enabled:
+        type: bool
+        description: Whether a horizontal pod autoscaler is deployed for the metal-apiserver.
+      metal_apiserver_hpa_max:
+        type: int
+        description: Maximum replicas of the metal-apiserver HPA.
+      metal_apiserver_hpa_min:
+        type: int
+        description: Minimum replicas of the metal-apiserver HPA.
+      metal_apiserver_hpa_cpu_percentage:
+        type: int
+        description: Target CPU utilization percentage of the metal-apiserver HPA.
+      metal_apiserver_resources:
+        type: dict
+        description: Resource requests and limits for the metal-apiserver container.
+      metal_apiserver_auditing_timescaledb_enabled:
+        type: raw
+        description: Whether auditing to timescaledb is enabled for the metal-apiserver.
+      metal_apiserver_auditing_timescaledb_host:
+        type: str
+        description: Host of the auditing timescaledb for the metal-apiserver.
+      metal_apiserver_auditing_timescaledb_port:
+        type: str
+        description: Port of the auditing timescaledb for the metal-apiserver.
+      metal_apiserver_auditing_timescaledb_db:
+        type: str
+        description: Database name of the auditing timescaledb for the metal-apiserver.
+      metal_apiserver_auditing_timescaledb_user:
+        type: str
+        description: User of the auditing timescaledb for the metal-apiserver.
+      metal_apiserver_auditing_timescaledb_password:
+        type: str
+        no_log: true
+        description: Password of the auditing timescaledb for the metal-apiserver.
+      metal_apiserver_auditing_timescaledb_retention:
+        type: str
+        description: Retention period for audit traces of the metal-apiserver.
+      metal_apiserver_auditing_splunk_enabled:
+        type: raw
+        description: Whether auditing to splunk is enabled for the metal-apiserver.
+      metal_apiserver_auditing_splunk_endpoint:
+        type: str
+        description: Splunk HEC endpoint for metal-apiserver auditing.
+      metal_apiserver_auditing_splunk_hec_token:
+        type: str
+        no_log: true
+        description: Splunk HEC token for metal-apiserver auditing.
+      metal_apiserver_auditing_splunk_source:
+        type: str
+        description: Splunk source for metal-apiserver auditing.
+      metal_apiserver_auditing_splunk_source_type:
+        type: str
+        description: Splunk source type for metal-apiserver auditing.
+      metal_apiserver_auditing_splunk_index:
+        type: str
+        description: Splunk index for metal-apiserver auditing.
+      metal_apiserver_auditing_splunk_host:
+        type: str
+        description: Splunk host field for metal-apiserver auditing.
+      metal_apiserver_auditing_splunk_ca:
+        type: str
+        description: CA certificate for the splunk endpoint of metal-apiserver auditing.
+      metal_apiserver_rate_limiting_max_requests_per_minute:
+        type: int
+        description: Maximum authenticated requests per minute for the metal-apiserver.
+      metal_apiserver_rate_limiting_max_unauthenticated_requests_per_minute:
+        type: int
+        description: Maximum unauthenticated requests per minute for the metal-apiserver.
+      metal_apiserver_oidc_discovery_url:
+        type: str
+        description: OIDC discovery URL for the metal-apiserver.
+      metal_apiserver_oidc_end_session_url:
+        type: str
+        description: OIDC end session URL for the metal-apiserver.
+      metal_apiserver_oidc_client_id:
+        type: str
+        description: OIDC client id for the metal-apiserver. Required when metal_apiserver_enabled is true. Read from the zitadel-client-credentials secret by default.
+      metal_apiserver_oidc_client_secret:
+        type: str
+        no_log: true
+        description: OIDC client secret for the metal-apiserver. Required when metal_apiserver_enabled is true. Read from the zitadel-client-credentials secret by default.
+      metal_apiserver_tls_skip_verify:
+        type: bool
+        description: Whether the metal-apiserver skips TLS certificate verification.
+      metal_apiserver_session_secret:
+        type: str
+        no_log: true
+        description: Session secret of the metal-apiserver.
+      metal_apiserver_secure_cookie:
+        type: bool
+        description: Whether the metal-apiserver uses secure cookies.
+      metal_apiserver_pdb_enabled:
+        type: bool
+        description: Whether a pod disruption budget is deployed for the metal-apiserver.
+      metal_apiserver_pdb_min_available:
+        type: int
+        description: Minimum available pods of the metal-apiserver PDB.
+      metal_apiserver_httproute_enabled:
+        type: bool
+        description: Whether to expose the metal-apiserver through a GatewayAPI HTTPRoute instead of an ingress.
+      metal_apiserver_httproute_hostnames:
+        type: list
+        elements: str
+        description: Hostnames for the metal-apiserver HTTPRoute.
+      metal_apiserver_httproute_parent_refs:
+        type: list
+        elements: dict
+        description: Parent references for the metal-apiserver HTTPRoute.
+      metal_apiserver_httproute_https_redirect:
+        type: dict
+        description: HTTPS redirect configuration for the metal-apiserver HTTPRoute.
+      metal_apiserver_token_create_schedule:
+        type: str
+        description: Cron schedule for the metal-apiserver token creation job.
+      metal_apiserver_tokens:
+        type: dict
+        description: Admin tokens created by the metal-apiserver token creation job.
+      metal_apiserver_headscale_enabled:
+        type: bool
+        description: Whether headscale VPN integration is enabled for the metal-apiserver.
+      metal_apiserver_headscale_tls:
+        type: bool
+        description: Whether the headscale control plane address of the metal-apiserver uses https.
+      metal_apiserver_headscale_api_key:
+        type: str
+        no_log: true
+        description: The headscale API key used by the metal-apiserver. Read from the headscale-api-key secret by default.
+      metal_apiserver_headscale_control_plane_address:
+        type: str
+        description: The external headscale control plane address used by the metal-apiserver.
+      metal_apiserver_headscale_internal_api_address:
+        type: str
+        description: The internal headscale API address used by the metal-apiserver.
+      metal_api_image_pull_policy:
+        type: str
+        description: Image pull policy for the metal-api container.
+      metal_api_image_name:
+        type: str
+        description: Image name of the metal-api. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_api_image_tag:
+        type: str
+        description: Image tag of the metal-api. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_api_replicas:
+        type: int
+        description: Amount of metal-api replicas.
+      metal_api_hpa_enabled:
+        type: bool
+        description: Whether a horizontal pod autoscaler is deployed for the metal-api.
+      metal_api_hpa_max:
+        type: int
+        description: Maximum replicas of the metal-api HPA.
+      metal_api_hpa_min:
+        type: int
+        description: Minimum replicas of the metal-api HPA.
+      metal_api_hpa_cpu_percentage:
+        type: int
+        description: Target CPU utilization percentage of the metal-api HPA.
+      metal_api_base_path:
+        type: str
+        description: The base path of the metal-api.
+      metal_api_dex_address:
+        type: str
+        description: The dex address used by the metal-api for OIDC.
+      metal_api_dex_clientid:
+        type: str
+        description: The dex client id used by the metal-api for OIDC.
+      metal_api_db_address:
+        type: str
+        description: Address of the metal-db.
+      metal_api_db_password:
+        type: str
+        no_log: true
+        description: Password of the metal-db.
+      metal_api_ipam_grpc_server_endpoint:
+        type: str
+        description: Endpoint of the ipam gRPC server.
+      metal_api_nsq_tcp_address:
+        type: str
+        description: The external nsqd TCP address.
+      metal_api_nsq_http_address:
+        type: str
+        description: The internal nsqd HTTP address.
+      metal_api_nsq_lookupd_address:
+        type: str
+        description: The internal nsq-lookupd address.
+      metal_api_nsq_tls_enabled:
+        type: bool
+        description: Whether TLS is used for the nsqd connection.
+      metal_api_nsq_tls_secret_name:
+        type: str
+        description: Name of the secret containing the nsqd TLS certificates.
+      metal_api_nsq_tls_checksum:
+        type: str
+        description: Checksum over the nsqd TLS secret used to trigger pod restarts on certificate changes.
+      metal_api_grpc_tls_enabled:
+        type: bool
+        description: Whether TLS is enabled for the metal-api gRPC server.
+      metal_api_grpc_certs_ca_cert:
+        type: str
+        required: true
+        description: The metal-api gRPC CA certificate content.
+      metal_api_grpc_certs_server_cert:
+        type: str
+        required: true
+        description: The metal-api gRPC server certificate content.
+      metal_api_grpc_certs_server_key:
+        type: str
+        required: true
+        no_log: true
+        description: The metal-api gRPC server certificate key content.
+      metal_api_bmc_superuser_enabled:
+        type: bool
+        description: Whether the BMC superuser is enabled.
+      metal_api_bmc_superuser_pwd:
+        type: str
+        no_log: true
+        description: Password of the BMC superuser.
+      metal_api_view_key:
+        type: str
+        no_log: true
+        description: HMAC key for the metal-api view access role.
+      metal_api_edit_key:
+        type: str
+        no_log: true
+        description: HMAC key for the metal-api edit access role.
+      metal_api_admin_key:
+        type: str
+        no_log: true
+        description: HMAC key for the metal-api admin access role.
+      metal_api_sizes:
+        type: list
+        elements: dict
+        description: Machine sizes applied to the metal-api.
+      metal_api_images:
+        type: list
+        elements: dict
+        description: Machine images applied to the metal-api.
+      metal_api_partitions:
+        type: list
+        elements: dict
+        description: Partitions applied to the metal-api.
+      metal_api_networks:
+        type: list
+        elements: dict
+        description: Networks applied to the metal-api.
+      metal_api_ips:
+        type: list
+        elements: dict
+        description: IPs applied to the metal-api.
+      metal_api_filesystemlayouts:
+        type: list
+        elements: dict
+        description: Filesystem layouts applied to the metal-api.
+      metal_api_sizeimageconstraints:
+        type: list
+        elements: dict
+        description: Size image constraints applied to the metal-api.
+      metal_api_size_reservations:
+        type: list
+        elements: dict
+        description: Size reservations applied to the metal-api.
+      metal_api_resources:
+        type: dict
+        description: Resource requests and limits for the metal-api container.
+      metal_api_s3_enabled:
+        type: bool
+        description: Whether S3 is configured for serving firmware.
+      metal_api_s3_address:
+        type: str
+        description: Address of the S3 endpoint for firmware. Required when metal_api_s3_enabled is true.
+      metal_api_s3_key:
+        type: str
+        description: Access key of the S3 endpoint for firmware.
+      metal_api_s3_secret:
+        type: str
+        no_log: true
+        description: Secret key of the S3 endpoint for firmware.
+      metal_api_s3_firmware_bucket:
+        type: str
+        description: S3 bucket containing the firmware.
+      metal_api_password_reason_minlength:
+        type: int
+        description: Minimum length of the reason for requesting the machine console password.
+      metal_api_release_version:
+        type: str
+        description: The metal-stack release version reported by the metal-api.
+      minimum_client_version:
+        type: str
+        description: The minimum metalctl client version required by the metal-api.
+      metal_api_pdb_enabled:
+        type: bool
+        description: Whether a pod disruption budget is deployed for the metal-api.
+      metal_api_pdb_min_available:
+        type: int
+        description: Minimum available pods of the metal-api PDB.
+      metal_api_httproute_enabled:
+        type: bool
+        description: Whether to expose the metal-api through a GatewayAPI HTTPRoute instead of an ingress.
+      metal_api_httproute_hostnames:
+        type: list
+        elements: str
+        description: Hostnames for the metal-api HTTPRoute.
+      metal_api_httproute_parent_refs:
+        type: list
+        elements: dict
+        description: Parent references for the metal-api HTTPRoute.
+      metal_api_httproute_https_redirect:
+        type: dict
+        description: HTTPS redirect configuration for the metal-api HTTPRoute.
+      metal_api_tcproute_enabled:
+        type: bool
+        description: Whether to expose the metal-api gRPC server through a GatewayAPI TCPRoute.
+      metal_api_tcproute_parent_refs:
+        type: list
+        elements: dict
+        description: Parent references for the metal-api TCPRoute.
+      metal_api_headscale_enabled:
+        type: bool
+        description: Whether headscale VPN integration is enabled for the metal-api.
+      metal_api_headscale_tls:
+        type: bool
+        description: Whether the headscale control plane address of the metal-api uses https.
+      metal_api_headscale_api_key:
+        type: str
+        no_log: true
+        description: The headscale API key used by the metal-api. Read from the headscale-api-key secret by default.
+      metal_api_headscale_control_plane_address:
+        type: str
+        description: The external headscale control plane address used by the metal-api.
+      metal_api_headscale_internal_api_address:
+        type: str
+        description: The internal headscale API address used by the metal-api.
+      metal_masterdata_api_image_pull_policy:
+        type: str
+        description: Image pull policy for the masterdata-api container.
+      metal_masterdata_api_image_name:
+        type: str
+        description: Image name of the masterdata-api. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_masterdata_api_image_tag:
+        type: str
+        description: Image tag of the masterdata-api. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_masterdata_api_tls_ca:
+        type: str
+        required: true
+        description: The masterdata-api CA certificate content.
+      metal_masterdata_api_tls_cert:
+        type: str
+        required: true
+        description: The masterdata-api server certificate content.
+      metal_masterdata_api_tls_cert_key:
+        type: str
+        required: true
+        no_log: true
+        description: The masterdata-api server certificate key content.
+      metal_masterdata_api_tls_client_cert:
+        type: str
+        required: true
+        description: The masterdata-api client certificate content.
+      metal_masterdata_api_tls_client_key:
+        type: str
+        required: true
+        no_log: true
+        description: The masterdata-api client certificate key content.
+      metal_masterdata_api_db_address:
+        type: str
+        description: Address of the masterdata-db.
+      metal_masterdata_api_db_port:
+        type: int
+        description: Port of the masterdata-db.
+      metal_masterdata_api_db_name:
+        type: str
+        description: Database name of the masterdata-db.
+      metal_masterdata_api_db_user:
+        type: str
+        description: User of the masterdata-db.
+      metal_masterdata_api_db_password:
+        type: str
+        no_log: true
+        description: Password of the masterdata-db.
+      metal_masterdata_api_provider_tenant:
+        type: str
+        description: The provider tenant of the masterdata-api.
+      metal_masterdata_api_hmac:
+        type: str
+        no_log: true
+        description: HMAC key of the masterdata-api.
+      metal_masterdata_api_resources:
+        type: dict
+        description: Resource requests and limits for the masterdata-api container.
+      metal_masterdata_api_pdb_enabled:
+        type: bool
+        description: Whether a pod disruption budget is deployed for the masterdata-api.
+      metal_masterdata_api_pdb_min_available:
+        type: int
+        description: Minimum available pods of the masterdata-api PDB.
+      metal_masterdata_api_tenants:
+        type: list
+        elements: dict
+        description: Tenants applied to the masterdata-api.
+      metal_masterdata_api_projects:
+        type: list
+        elements: dict
+        description: Projects applied to the masterdata-api.
+      metal_tenant_apiserver_image_pull_policy:
+        type: str
+        description: Image pull policy for the tenant-apiserver container.
+      metal_tenant_apiserver_image_name:
+        type: str
+        description: Image name of the tenant-apiserver. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_tenant_apiserver_image_tag:
+        type: str
+        description: Image tag of the tenant-apiserver. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_tenant_apiserver_db_address:
+        type: str
+        description: Address of the database used by the tenant-apiserver.
+      metal_tenant_apiserver_db_port:
+        type: int
+        description: Port of the database used by the tenant-apiserver.
+      metal_tenant_apiserver_db_name:
+        type: str
+        description: Database name used by the tenant-apiserver.
+      metal_tenant_apiserver_db_user:
+        type: str
+        description: Database user used by the tenant-apiserver.
+      metal_tenant_apiserver_db_password:
+        type: str
+        no_log: true
+        description: Database password used by the tenant-apiserver.
+      metal_tenant_apiserver_resources:
+        type: dict
+        description: Resource requests and limits for the tenant-apiserver container.
+      metal_tenant_apiserver_pdb_enabled:
+        type: bool
+        description: Whether a pod disruption budget is deployed for the tenant-apiserver.
+      metal_tenant_apiserver_pdb_min_available:
+        type: int
+        description: Minimum available pods of the tenant-apiserver PDB.
+      metal_tenant_apiserver_replicas:
+        type: int
+        description: Amount of tenant-apiserver replicas.
+      metal_ipam_image_pull_policy:
+        type: str
+        description: Image pull policy for the ipam container.
+      metal_ipam_image_name:
+        type: str
+        description: Image name of the ipam service. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_ipam_image_tag:
+        type: str
+        description: Image tag of the ipam service. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_ipam_db_address:
+        type: str
+        description: Address of the ipam-db.
+      metal_ipam_db_port:
+        type: int
+        description: Port of the ipam-db.
+      metal_ipam_db_name:
+        type: str
+        description: Database name of the ipam-db.
+      metal_ipam_db_user:
+        type: str
+        description: User of the ipam-db.
+      metal_ipam_db_password:
+        type: str
+        no_log: true
+        description: Password of the ipam-db.
+      metal_ipam_log_level:
+        type: str
+        description: Log level of the ipam service.
+      metal_ipam_resources:
+        type: dict
+        description: Resource requests and limits for the ipam container.
+      metal_ipam_pdb_enabled:
+        type: bool
+        description: Whether a pod disruption budget is deployed for the ipam service.
+      metal_ipam_pdb_min_available:
+        type: int
+        description: Minimum available pods of the ipam PDB.
+      metal_console_image_pull_policy:
+        type: str
+        description: Image pull policy for the metal-console container.
+      metal_console_image_name:
+        type: str
+        description: Image name of the metal-console. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_console_image_tag:
+        type: str
+        description: Image tag of the metal-console. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_console_enabled:
+        type: bool
+        description: Whether to deploy the metal-console.
+      metal_console_replicas:
+        type: int
+        description: Amount of metal-console replicas.
+      metal_console_resources:
+        type: dict
+        description: Resource requests and limits for the metal-console container.
+      metal_console_bmc_proxy_certs_server_key:
+        type: str
+        no_log: true
+        description: The metal-console BMC proxy server certificate key content.
+      metal_console_bmc_proxy_certs_server_pub:
+        type: str
+        description: The metal-console BMC proxy server public key content.
+      metal_console_bmc_proxy_certs_client_key:
+        type: str
+        no_log: true
+        description: The metal-console BMC proxy client certificate key content.
+      metal_console_bmc_proxy_certs_client_cert:
+        type: str
+        description: The metal-console BMC proxy client certificate content.
+      metal_console_bmc_proxy_certs_ca_cert:
+        type: str
+        description: The metal-console BMC proxy CA certificate content.
+      metal_console_pdb_enabled:
+        type: bool
+        description: Whether a pod disruption budget is deployed for the metal-console.
+      metal_console_pdb_min_available:
+        type: int
+        description: Minimum available pods of the metal-console PDB.
+      metal_console_tcproute_enabled:
+        type: bool
+        description: Whether to expose the metal-console through a GatewayAPI TCPRoute.
+      metal_console_tcproute_parent_refs:
+        type: list
+        elements: dict
+        description: Parent references for the metal-console TCPRoute.
+      metal_deploy_ingress:
+        type: bool
+        description: Whether to deploy the ingress resources.
+      metal_deploy_ingress_api_v1_rules:
+        type: raw
+        description: Whether ingress rules for the v1 metal-api are rendered.
+      metal_deploy_ingress_api_v2_rules:
+        type: raw
+        description: Whether ingress rules for the v2 metal-apiserver are rendered.
+      metal_ingress:
+        type: dict
+        description: Additional ingress configuration (e.g. annotations).
+      metal_ingress_dns:
+        type: str
+        description: Ingress DNS name of the metal-api.
+      metal_ingress_v2_dns:
+        type: str
+        description: Ingress DNS name of the metal-apiserver.
+      metal_auditing_timescaledb_enabled:
+        type: bool
+        description: Whether auditing to timescaledb is enabled.
+      metal_auditing_timescaledb_host:
+        type: str
+        description: Host of the auditing timescaledb.
+      metal_auditing_timescaledb_port:
+        type: str
+        description: Port of the auditing timescaledb.
+      metal_auditing_timescaledb_db:
+        type: str
+        description: Database name of the auditing timescaledb.
+      metal_auditing_timescaledb_user:
+        type: str
+        description: User of the auditing timescaledb.
+      metal_auditing_timescaledb_password:
+        type: str
+        no_log: true
+        description: Password of the auditing timescaledb.
+      metal_auditing_timescaledb_retention:
+        type: str
+        description: Retention period for audit traces.
+      metal_auditing_splunk_enabled:
+        type: bool
+        description: Whether auditing to splunk is enabled.
+      metal_auditing_splunk_endpoint:
+        type: str
+        description: Splunk HEC endpoint for auditing.
+      metal_auditing_splunk_hec_token:
+        type: str
+        no_log: true
+        description: Splunk HEC token for auditing.
+      metal_auditing_splunk_source:
+        type: str
+        description: Splunk source for auditing.
+      metal_auditing_splunk_source_type:
+        type: str
+        description: Splunk source type for auditing.
+      metal_auditing_splunk_index:
+        type: str
+        description: Splunk index for auditing.
+      metal_auditing_splunk_host:
+        type: str
+        description: Splunk host field for auditing.
+      metal_auditing_splunk_ca:
+        type: str
+        description: CA certificate for the splunk endpoint.
+      metal_auditing_search_backend:
+        type: str
+        description: The auditing backend used for searching audit traces.

--- a/control-plane/roles/metal/tasks/main.yaml
+++ b/control-plane/roles/metal/tasks/main.yaml
@@ -24,6 +24,8 @@
       - metal_ipam_image_tag is defined
       - metal_console_image_name is defined
       - metal_console_image_tag is defined
+      - metal_apiserver_image_name is defined
+      - metal_apiserver_image_tag is defined
       - metal_helm_chart_local_path is not none or metal_helm_chart is defined
       - metal_helm_chart_local_path is not none or metal_helm_chart_tag is defined
       - not metal_api_s3_enabled or metal_api_s3_address is not none

--- a/control-plane/roles/monitoring/meta/argument_specs.yaml
+++ b/control-plane/roles/monitoring/meta/argument_specs.yaml
@@ -1,0 +1,250 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys the control plane monitoring stack (kube-prometheus-stack, thanos, exporters, dashboards)
+    options:
+      monitoring_namespace:
+        type: str
+        description: The namespace to deploy the monitoring stack to.
+      monitoring_grafana_enabled:
+        type: bool
+        description: Whether Grafana and its dashboards are deployed.
+      monitoring_grafana_admin_password:
+        type: str
+        no_log: true
+        description: Admin password for Grafana.
+      monitoring_grafana_dashboard_timezone:
+        type: str
+        description: Timezone used in the Grafana dashboards.
+      monitoring_grafana_additional_datasources:
+        type: list
+        elements: dict
+        description: Additional Grafana datasources.
+      monitoring_grafana_github_oauth:
+        type: dict
+        description: GitHub OAuth configuration for Grafana (auth.github section).
+      monitoring_grafana_extra_secret_mounts:
+        type: list
+        elements: dict
+        description: Extra secret mounts for the Grafana pod.
+      monitoring_grafana_ingress_dns:
+        type: str
+        description: Ingress DNS name of Grafana.
+      monitoring_prometheus_ingress_dns:
+        type: str
+        description: Ingress DNS name of Prometheus.
+      monitoring_ingress_grafana_tls:
+        type: bool
+        description: Whether TLS is enabled on the Grafana ingress.
+      monitoring_prometheus_ingress_enabled:
+        type: bool
+        description: Whether to create an ingress for Prometheus.
+      monitoring_additional_ingress_annotations:
+        type: dict
+        description: Additional annotations for the monitoring ingresses.
+      monitoring_grafana_ingress_annotations:
+        type: dict
+        description: Additional annotations for the Grafana ingress.
+      monitoring_alertmanager_ingress_annotations:
+        type: dict
+        description: Additional annotations for the Alertmanager ingress.
+      monitoring_alertmanager_enabled:
+        type: bool
+        description: Whether the Alertmanager is deployed.
+      monitoring_alertmanager_ingress_enabled:
+        type: bool
+        description: Whether to create an ingress for the Alertmanager.
+      monitoring_alertmanager_ingress_dns:
+        type: str
+        description: Ingress DNS name of the Alertmanager.
+      monitoring_alertmanager_ingress_tls:
+        type: bool
+        description: Whether TLS is enabled on the Alertmanager ingress.
+      monitoring_alertmanager_ingress_basic_auth_user:
+        type: str
+        description: Basic auth user of the Alertmanager ingress.
+      monitoring_alertmanager_ingress_basic_auth_password:
+        type: str
+        no_log: true
+        description: Basic auth password of the Alertmanager ingress.
+      monitoring_alertmanager_ingress_basic_auth_password_salt:
+        type: str
+        no_log: true
+        description: Salt used for generating the htpasswd entry of the Alertmanager ingress.
+      monitoring_alertmanager_webhook_logger_repeat_interval:
+        type: str
+        description: Repeat interval for the webhook logger receiver.
+      monitoring_alertmanager_webhook_slack_repeat_interval:
+        type: str
+        description: Repeat interval for the slack receiver.
+      monitoring_alertmanager_additional_routes:
+        type: list
+        elements: dict
+        description: Additional Alertmanager routes.
+      monitoring_alertmanager_additional_receivers:
+        type: list
+        elements: dict
+        description: Additional Alertmanager receivers.
+      monitoring_slack_api_url:
+        type: str
+        no_log: true
+        description: Slack webhook URL for alert notifications.
+      monitoring_slack_notification_channel:
+        type: str
+        description: Slack channel for alert notifications.
+      event_exporter_enabled:
+        type: bool
+        description: Whether the kubernetes event-exporter is deployed.
+      monitoring_metal_api_url:
+        type: str
+        description: The metal-api URL scraped by the metal-metrics-exporter.
+      monitoring_metal_api_hmac:
+        type: str
+        no_log: true
+        description: The metal-api HMAC used by the metal-metrics-exporter.
+      monitoring_metal_api_authtype:
+        type: str
+        description: The metal-api HMAC auth type used by the metal-metrics-exporter.
+      monitoring_rethinkdb_exporter_metal_db_password:
+        type: str
+        no_log: true
+        description: Password of the metal-db used by the rethinkdb-exporter.
+      monitoring_rethinkdb_exporter_metal_db_endpoint:
+        type: str
+        description: Endpoint of the metal-db used by the rethinkdb-exporter.
+      monitoring_gardener_enabled:
+        type: raw
+        description: Whether the Gardener monitoring components are deployed. Enabled automatically when monitoring_gardener_seeds is non-empty.
+      monitoring_gardener_seeds:
+        type: list
+        elements: str
+        description: The Gardener seeds to monitor.
+      monitoring_virtual_garden_kubeconfig_refresher_cluster_provider:
+        type: str
+        description: "Cluster provider used by the virtual-garden-kubeconfig-refresher (one of: gcp, metalstackcloud, static). Required when Gardener monitoring is enabled."
+      monitoring_virtual_garden_kubeconfig_refresher_gcp_project_id:
+        type: str
+        description: GCP project id for the virtual-garden-kubeconfig-refresher.
+      monitoring_virtual_garden_kubeconfig_refresher_gcp_location:
+        type: str
+        description: GCP location for the virtual-garden-kubeconfig-refresher.
+      monitoring_virtual_garden_kubeconfig_refresher_gcp_cluster_name:
+        type: str
+        description: GCP cluster name for the virtual-garden-kubeconfig-refresher.
+      monitoring_virtual_garden_kubeconfig_refresher_metal_stack_cloud_project_id:
+        type: str
+        description: metalstack.cloud project id for the virtual-garden-kubeconfig-refresher.
+      monitoring_virtual_garden_kubeconfig_refresher_metal_stack_cloud_api_token:
+        type: str
+        no_log: true
+        description: metalstack.cloud API token for the virtual-garden-kubeconfig-refresher.
+      monitoring_virtual_garden_kubeconfig_refresher_metal_stack_cloud_cluster_id:
+        type: str
+        description: metalstack.cloud cluster id for the virtual-garden-kubeconfig-refresher.
+      monitoring_virtual_garden_kubeconfig_refresher_static_kubeconfig:
+        type: str
+        no_log: true
+        description: Static kubeconfig content for the garden cluster (cluster provider static).
+      monitoring_virtual_garden_kubeconfig_refresher_garden_cluster_local_rbac:
+        type: bool
+        description: Whether to create local RBAC resources for accessing the garden cluster.
+      monitoring_prometheus_operator_enabled:
+        type: bool
+        description: Whether the prometheus operator is deployed.
+      monitoring_prometheus_image_tag:
+        type: str
+        description: Overrides the prometheus image tag of the kube-prometheus-stack chart.
+      monitoring_prometheus_storage_spec:
+        type: str
+        description: Storage spec (YAML string) for the prometheus statefulset.
+      monitoring_prometheus_core_dns_enabled:
+        type: bool
+        description: Whether CoreDNS monitoring is enabled.
+      monitoring_prometheus_kube_dns_enabled:
+        type: bool
+        description: Whether kube-dns monitoring is enabled.
+      monitoring_prometheus_kube_proxy_enabled:
+        type: bool
+        description: Whether kube-proxy monitoring is enabled.
+      monitoring_prometheus_kube_scheduler_enabled:
+        type: bool
+        description: Whether kube-scheduler monitoring is enabled.
+      monitoring_prometheus_kube_etcd_enabled:
+        type: bool
+        description: Whether etcd monitoring is enabled.
+      monitoring_prometheus_kube_controller_manager_enabled:
+        type: bool
+        description: Whether kube-controller-manager monitoring is enabled.
+      monitoring_prometheus_kubelet_enabled:
+        type: bool
+        description: Whether kubelet monitoring is enabled.
+      monitoring_prometheus_default_rules_enabled:
+        type: bool
+        description: Whether the default prometheus rules of the kube-prometheus-stack are enabled.
+      monitoring_prometheus_remote_write:
+        type: list
+        elements: dict
+        description: Prometheus remote_write targets (name, url, username, password).
+      monitoring_prometheus_kube_proxy_service_selector:
+        type: dict
+        description: Service selector for the kube-proxy monitoring service.
+      monitoring_thanos_enabled:
+        type: bool
+        description: Whether thanos is deployed.
+      monitoring_thanos_receive_enabled:
+        type: bool
+        description: Whether thanos receive is deployed.
+      monitoring_thanos_receive_ingress_enabled:
+        type: bool
+        description: Whether to create an ingress for thanos receive.
+      monitoring_thanos_receive_ingress_dns:
+        type: str
+        description: Ingress DNS name of thanos receive.
+      monitoring_thanos_receive_ingress_annotations:
+        type: list
+        description: Additional annotations for the thanos receive ingress.
+      monitoring_thanos_receive_ingress_tls:
+        type: bool
+        description: Whether TLS is enabled on the thanos receive ingress.
+      monitoring_thanos_receive_ingress_tls_gardener_managed:
+        type: bool
+        description: Whether the thanos receive ingress certificate is managed by Gardener.
+      monitoring_thanos_receive_ingress_basic_auth_user:
+        type: str
+        description: Basic auth user of the thanos receive ingress.
+      monitoring_thanos_receive_ingress_basic_auth_password:
+        type: str
+        no_log: true
+        description: Basic auth password of the thanos receive ingress.
+      monitoring_thanos_receive_ingress_basic_auth_password_salt:
+        type: str
+        no_log: true
+        description: Salt used for generating the htpasswd entry of the thanos receive ingress.
+      monitoring_thanos_receive_size:
+        type: str
+        description: Size of the thanos receive persistent volume.
+      monitoring_thanos_receive_resource_preset:
+        type: str
+        description: Resource preset of thanos receive.
+      monitoring_thanos_receive_probe_failure_threshold:
+        type: int
+        description: Probe failure threshold of thanos receive.
+      monitoring_thanos_compactor_size:
+        type: str
+        description: Size of the thanos compactor persistent volume.
+      monitoring_thanos_compactor_resource_preset:
+        type: str
+        description: Resource preset of the thanos compactor.
+      monitoring_thanos_compactor_storage_class:
+        type: str
+        description: Storage class of the thanos compactor persistent volume.
+      monitoring_thanos_object_store_resource_preset:
+        type: str
+        description: Resource preset of the thanos object store components.
+      monitoring_thanos_object_store_probe_failure_threshold:
+        type: int
+        description: Probe failure threshold of the thanos object store components.
+      monitoring_thanos_object_store_config:
+        type: str
+        no_log: true
+        description: Thanos object store configuration (YAML string, contains credentials).

--- a/control-plane/roles/monitoring/tasks/main.yaml
+++ b/control-plane/roles/monitoring/tasks/main.yaml
@@ -7,6 +7,8 @@
     fail_msg: "not all mandatory variables given, check role documentation"
     quiet: true
     that:
+      - metal_metrics_exporter_image_name is defined
+      - metal_metrics_exporter_image_tag is defined
       - rethinkdb_exporter_name is defined
       - rethinkdb_exporter_tag is defined
       - gardener_metrics_exporter_image_name is defined

--- a/control-plane/roles/nsq/meta/argument_specs.yaml
+++ b/control-plane/roles/nsq/meta/argument_specs.yaml
@@ -1,0 +1,77 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys nsq (nsqd, nsq-lookupd, nsq-admin) to the control plane cluster
+    options:
+      nsq_image_name:
+        type: str
+        description: Image name of nsq. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      nsq_image_tag:
+        type: str
+        description: Image tag of nsq. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      nsq_namespace:
+        type: str
+        description: The namespace to deploy nsq to.
+      nsq_image_pull_policy:
+        type: str
+        description: Image pull policy for the nsq containers.
+      nsq_set_resource_limits:
+        type: bool
+        description: Whether to set resource requests and limits on the nsq containers.
+      nsq_nsqd_resources:
+        type: dict
+        description: Resource requests and limits for the nsqd container.
+      nsq_nsq_lookupd_resources:
+        type: dict
+        description: Resource requests and limits for the nsq-lookupd container.
+      nsq_nsq_admin_resources:
+        type: dict
+        description: Resource requests and limits for the nsq-admin container.
+      nsq_log_level:
+        type: str
+        description: Log level of the nsq components.
+      nsq_broadcast_address:
+        type: str
+        description: The address nsqd broadcasts to consumers.
+      nsq_nsqd_data_size:
+        type: str
+        description: Size of the nsqd data volume.
+      nsq_tls_enabled:
+        type: bool
+        description: Whether TLS is enabled for nsqd.
+      nsq_tls_require:
+        type: str
+        description: The nsqd tls-required setting.
+      nsq_certs_client_key:
+        type: str
+        no_log: true
+        description: The nsq client certificate key content.
+      nsq_certs_client_cert:
+        type: str
+        description: The nsq client certificate content.
+      nsq_certs_ca_cert:
+        type: str
+        description: The nsq CA certificate content.
+      nsq_registry_auth_enabled:
+        type: raw
+        description: Whether to deploy an image pull secret for the registry.
+      nsq_registry_auth:
+        type: dict
+        no_log: true
+        description: Docker auth configuration for the image pull secret.
+      nsq_tcproute_enabled:
+        type: bool
+        description: Whether to expose nsqd through a GatewayAPI TCPRoute instead of an ingress.
+      nsq_tcproute_parent_refs:
+        type: list
+        elements: dict
+        description: Parent references for the nsqd TCPRoute.
+      nsq_enable_security_context:
+        type: bool
+        description: Whether to render the pod and container security contexts.
+      nsq_sts_security_context:
+        type: dict
+        description: Pod security context for the statefulset.
+      nsq_container_security_context:
+        type: dict
+        description: Security context for the containers.

--- a/control-plane/roles/postgres-backup-restore/meta/argument_specs.yaml
+++ b/control-plane/roles/postgres-backup-restore/meta/argument_specs.yaml
@@ -1,0 +1,149 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys a PostgreSQL database with the backup-restore-sidecar
+    options:
+      postgres_name:
+        type: str
+        description: Name of the postgres deployment.
+      postgres_namespace:
+        type: str
+        description: The namespace to deploy postgres to.
+      postgres_image_pull_policy:
+        type: str
+        description: Image pull policy for the postgres container.
+      postgres_storage_size:
+        type: str
+        description: Size of the persistent volume.
+      postgres_storage_class:
+        type: str
+        description: Storage class of the persistent volume.
+      postgres_db:
+        type: str
+        description: Name of the database to create.
+      postgres_user:
+        type: str
+        description: User of the postgres database.
+      postgres_password:
+        type: str
+        no_log: true
+        description: Password of the postgres database.
+      postgres_max_connections:
+        type: raw
+        description: Maximum amount of database connections.
+      postgres_shared_libraries_preload:
+        type: list
+        elements: str
+        description: Libraries to preload via shared_preload_libraries.
+      postgres_shared_buffers:
+        type: str
+        description: PostgreSQL shared_buffers setting.
+      postgres_maintenance_work_mem:
+        type: str
+        description: PostgreSQL maintenance_work_mem setting.
+      postgres_work_mem:
+        type: str
+        description: PostgreSQL work_mem setting.
+      postgres_effective_cache_size:
+        type: str
+        description: PostgreSQL effective_cache_size setting.
+      postgres_backup_restore_sidecar_image_pull_policy:
+        type: str
+        description: Image pull policy for the backup-restore-sidecar container.
+      postgres_backup_restore_sidecar_provider:
+        type: str
+        description: Backup provider used by the backup-restore-sidecar (local, gcp or s3).
+      postgres_backup_restore_sidecar_backup_cron_schedule:
+        type: str
+        description: Cron schedule for creating backups.
+      postgres_backup_restore_sidecar_log_level:
+        type: str
+        description: Log level of the backup-restore-sidecar.
+      postgres_backup_restore_sidecar_object_prefix:
+        type: str
+        description: Object prefix used for backups in the object store.
+      postgres_backup_restore_sidecar_object_max_keep:
+        type: raw
+        description: Maximum amount of backup objects to keep.
+      postgres_backup_restore_sidecar_object_days_max_keep:
+        type: raw
+        description: Maximum age in days of backup objects to keep.
+      postgres_backup_restore_sidecar_s3_request_checksum_calculation:
+        type: str
+        description: S3 request checksum calculation setting (e.g. when_required for non-AWS S3 endpoints).
+      postgres_backup_restore_sidecar_encryption_key:
+        type: str
+        no_log: true
+        description: Encryption key (32 characters) for encrypting backups.
+      postgres_backup_restore_sidecar_gcp_bucket_name:
+        type: str
+        description: GCP bucket name for storing backups.
+      postgres_backup_restore_sidecar_gcp_backup_location:
+        type: str
+        description: GCP bucket location for storing backups.
+      postgres_backup_restore_sidecar_gcp_project_id:
+        type: str
+        description: GCP project id of the backup bucket.
+      postgres_backup_restore_sidecar_gcp_serviceaccount_json:
+        type: str
+        no_log: true
+        description: GCP service account JSON used for accessing the backup bucket.
+      postgres_backup_restore_sidecar_s3_bucket_name:
+        type: str
+        description: S3 bucket name for storing backups.
+      postgres_backup_restore_sidecar_s3_region:
+        type: str
+        description: S3 region of the backup bucket.
+      postgres_backup_restore_sidecar_s3_endpoint:
+        type: str
+        description: S3 endpoint of the backup bucket.
+      postgres_backup_restore_sidecar_s3_access_key:
+        type: str
+        description: S3 access key for the backup bucket.
+      postgres_backup_restore_sidecar_s3_secret_key:
+        type: str
+        no_log: true
+        description: S3 secret key for the backup bucket.
+      postgres_backup_restore_sidecar_s3_insecure_skip_verify:
+        type: raw
+        description: Whether to skip TLS certificate verification for the S3 endpoint.
+      postgres_backup_restore_sidecar_s3_trusted_ca_cert:
+        type: str
+        description: Trusted CA certificate for the S3 endpoint.
+      postgres_resources:
+        type: dict
+        description: Resource requests and limits for the postgres container.
+      postgres_backup_restore_sidecar_resources:
+        type: dict
+        description: Resource requests and limits for the backup-restore-sidecar container.
+      postgres_init_resources:
+        type: dict
+        description: Resource requests and limits for the init container.
+      postgres_registry_auth_enabled:
+        type: raw
+        description: Whether to deploy an image pull secret for the registry.
+      postgres_registry_auth:
+        type: dict
+        no_log: true
+        description: Docker auth configuration for the image pull secret.
+      postgres_enable_security_context:
+        type: bool
+        description: Whether to render the pod and container security contexts.
+      postgres_sts_security_context:
+        type: dict
+        description: Pod security context for the statefulset.
+      postgres_container_security_context:
+        type: dict
+        description: Security context for the containers.
+      postgres_image_name:
+        type: str
+        description: Image name of postgres. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      postgres_image_tag:
+        type: str
+        description: Image tag of postgres. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      postgres_backup_restore_sidecar_image_name:
+        type: str
+        description: Image name of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      postgres_backup_restore_sidecar_image_tag:
+        type: str
+        description: Image tag of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.

--- a/control-plane/roles/rethinkdb-backup-restore/meta/argument_specs.yaml
+++ b/control-plane/roles/rethinkdb-backup-restore/meta/argument_specs.yaml
@@ -1,0 +1,127 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys a RethinkDB database with the backup-restore-sidecar
+    options:
+      rethinkdb_name:
+        type: str
+        description: Name of the rethinkdb deployment.
+      rethinkdb_namespace:
+        type: str
+        description: The namespace to deploy rethinkdb to.
+      rethinkdb_image_pull_policy:
+        type: str
+        description: Image pull policy for the rethinkdb container.
+      rethinkdb_storage_size:
+        type: str
+        description: Size of the persistent volume.
+      rethinkdb_storage_class:
+        type: str
+        description: Storage class of the persistent volume.
+      rethinkdb_password:
+        type: str
+        no_log: true
+        description: Password of the rethinkdb database.
+      rethinkdb_backup_restore_sidecar_image_pull_policy:
+        type: str
+        description: Image pull policy for the backup-restore-sidecar container.
+      rethinkdb_backup_restore_sidecar_provider:
+        type: str
+        description: Backup provider used by the backup-restore-sidecar (local, gcp or s3).
+      rethinkdb_backup_restore_sidecar_backup_cron_schedule:
+        type: str
+        description: Cron schedule for creating backups.
+      rethinkdb_backup_restore_sidecar_log_level:
+        type: str
+        description: Log level of the backup-restore-sidecar.
+      rethinkdb_backup_restore_sidecar_gcp_bucket_name:
+        type: str
+        description: GCP bucket name for storing backups.
+      rethinkdb_backup_restore_sidecar_gcp_backup_location:
+        type: str
+        description: GCP bucket location for storing backups.
+      rethinkdb_backup_restore_sidecar_gcp_project_id:
+        type: str
+        description: GCP project id of the backup bucket.
+      rethinkdb_backup_restore_sidecar_gcp_serviceaccount_json:
+        type: str
+        no_log: true
+        description: GCP service account JSON used for accessing the backup bucket.
+      rethinkdb_backup_restore_sidecar_s3_bucket_name:
+        type: str
+        description: S3 bucket name for storing backups.
+      rethinkdb_backup_restore_sidecar_s3_region:
+        type: str
+        description: S3 region of the backup bucket.
+      rethinkdb_backup_restore_sidecar_s3_endpoint:
+        type: str
+        description: S3 endpoint of the backup bucket.
+      rethinkdb_backup_restore_sidecar_s3_access_key:
+        type: str
+        description: S3 access key for the backup bucket.
+      rethinkdb_backup_restore_sidecar_s3_secret_key:
+        type: str
+        no_log: true
+        description: S3 secret key for the backup bucket.
+      rethinkdb_backup_restore_sidecar_s3_insecure_skip_verify:
+        type: raw
+        description: Whether to skip TLS certificate verification for the S3 endpoint.
+      rethinkdb_backup_restore_sidecar_s3_trusted_ca_cert:
+        type: str
+        description: Trusted CA certificate for the S3 endpoint.
+      rethinkdb_backup_restore_sidecar_object_max_keep:
+        type: raw
+        description: Maximum amount of backup objects to keep.
+      rethinkdb_backup_restore_sidecar_object_days_max_keep:
+        type: raw
+        description: Maximum age in days of backup objects to keep.
+      rethinkdb_backup_restore_sidecar_s3_request_checksum_calculation:
+        type: str
+        description: S3 request checksum calculation setting (e.g. when_required for non-AWS S3 endpoints).
+      rethinkdb_backup_restore_sidecar_encryption_key:
+        type: str
+        no_log: true
+        description: Encryption key (32 characters) for encrypting backups.
+      rethinkdb_expose_frontend:
+        type: bool
+        description: Whether to expose the RethinkDB web frontend through an ingress.
+      rethinkdb_ingress_dns:
+        type: str
+        description: Ingress DNS name for the RethinkDB web frontend.
+      rethinkdb_resources:
+        type: dict
+        description: Resource requests and limits for the rethinkdb container.
+      rethinkdb_backup_restore_sidecar_resources:
+        type: dict
+        description: Resource requests and limits for the backup-restore-sidecar container.
+      rethinkdb_init_resources:
+        type: dict
+        description: Resource requests and limits for the init container.
+      rethinkdb_registry_auth_enabled:
+        type: raw
+        description: Whether to deploy an image pull secret for the registry.
+      rethinkdb_registry_auth:
+        type: dict
+        no_log: true
+        description: Docker auth configuration for the image pull secret.
+      rethinkdb_enable_security_context:
+        type: bool
+        description: Whether to render the pod and container security contexts.
+      rethinkdb_sts_security_context:
+        type: dict
+        description: Pod security context for the statefulset.
+      rethinkdb_container_security_context:
+        type: dict
+        description: Security context for the containers.
+      rethinkdb_image_name:
+        type: str
+        description: Image name of rethinkdb. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      rethinkdb_image_tag:
+        type: str
+        description: Image tag of rethinkdb. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      rethinkdb_backup_restore_sidecar_image_name:
+        type: str
+        description: Image name of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      rethinkdb_backup_restore_sidecar_image_tag:
+        type: str
+        description: Image tag of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.

--- a/control-plane/roles/rethinkdb-backup-restore/tasks/main.yml
+++ b/control-plane/roles/rethinkdb-backup-restore/tasks/main.yml
@@ -14,13 +14,6 @@
       - rethinkdb_backup_restore_sidecar_encryption_key is none or rethinkdb_backup_restore_sidecar_encryption_key | length == 32
       - rethinkdb_backup_restore_sidecar_provider in ["local", "gcp", "s3"]
 
-- name: Check mandatory variables for this role are set
-  ansible.builtin.assert:
-    fail_msg: "not all mandatory variables given, check role documentation"
-    quiet: true
-    that:
-      - rethinkdb_backup_restore_sidecar_image_tag is defined
-
 - name: Deploy rethinkdb (backup-restore)
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'rethinkdb.yaml') }}"

--- a/control-plane/roles/valkey/meta/argument_specs.yaml
+++ b/control-plane/roles/valkey/meta/argument_specs.yaml
@@ -1,0 +1,111 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys a Valkey instance with the backup-restore-sidecar
+    options:
+      valkey_name:
+        type: str
+        description: Name of the valkey deployment.
+      valkey_namespace:
+        type: str
+        description: The namespace to deploy valkey to.
+      valkey_image_pull_policy:
+        type: str
+        description: Image pull policy for the valkey container.
+      valkey_storage_size:
+        type: str
+        description: Size of the persistent volume.
+      valkey_storage_class:
+        type: str
+        description: Storage class of the persistent volume.
+      valkey_backup_restore_sidecar_image_pull_policy:
+        type: str
+        description: Image pull policy for the backup-restore-sidecar container.
+      valkey_backup_restore_sidecar_provider:
+        type: str
+        description: Backup provider used by the backup-restore-sidecar (local, gcp or s3).
+      valkey_backup_restore_sidecar_backup_cron_schedule:
+        type: str
+        description: Cron schedule for creating backups.
+      valkey_backup_restore_sidecar_log_level:
+        type: str
+        description: Log level of the backup-restore-sidecar.
+      valkey_backup_restore_sidecar_gcp_bucket_name:
+        type: str
+        description: GCP bucket name for storing backups.
+      valkey_backup_restore_sidecar_gcp_backup_location:
+        type: str
+        description: GCP bucket location for storing backups.
+      valkey_backup_restore_sidecar_gcp_project_id:
+        type: str
+        description: GCP project id of the backup bucket.
+      valkey_backup_restore_sidecar_gcp_serviceaccount_json:
+        type: str
+        no_log: true
+        description: GCP service account JSON used for accessing the backup bucket.
+      valkey_backup_restore_sidecar_s3_bucket_name:
+        type: str
+        description: S3 bucket name for storing backups.
+      valkey_backup_restore_sidecar_s3_region:
+        type: str
+        description: S3 region of the backup bucket.
+      valkey_backup_restore_sidecar_s3_endpoint:
+        type: str
+        description: S3 endpoint of the backup bucket.
+      valkey_backup_restore_sidecar_s3_access_key:
+        type: str
+        description: S3 access key for the backup bucket.
+      valkey_backup_restore_sidecar_s3_secret_key:
+        type: str
+        no_log: true
+        description: S3 secret key for the backup bucket.
+      valkey_backup_restore_sidecar_s3_insecure_skip_verify:
+        type: raw
+        description: Whether to skip TLS certificate verification for the S3 endpoint.
+      valkey_backup_restore_sidecar_s3_trusted_ca_cert:
+        type: str
+        description: Trusted CA certificate for the S3 endpoint.
+      valkey_backup_restore_sidecar_object_max_keep:
+        type: raw
+        description: Maximum amount of backup objects to keep.
+      valkey_backup_restore_sidecar_encryption_key:
+        type: str
+        no_log: true
+        description: Encryption key (32 characters) for encrypting backups.
+      valkey_resources:
+        type: dict
+        description: Resource requests and limits for the valkey container.
+      valkey_backup_restore_sidecar_resources:
+        type: dict
+        description: Resource requests and limits for the backup-restore-sidecar container.
+      valkey_init_resources:
+        type: dict
+        description: Resource requests and limits for the init container.
+      valkey_registry_auth_enabled:
+        type: raw
+        description: Whether to deploy an image pull secret for the registry.
+      valkey_registry_auth:
+        type: dict
+        no_log: true
+        description: Docker auth configuration for the image pull secret.
+      valkey_enable_security_context:
+        type: bool
+        description: Whether to render the pod and container security contexts.
+      valkey_sts_security_context:
+        type: dict
+        description: Pod security context for the statefulset.
+      valkey_container_security_context:
+        type: dict
+        description: Security context for the containers.
+      valkey_image_name:
+        type: str
+        description: Image name of valkey. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      valkey_image_tag:
+        type: str
+        description: Image tag of valkey. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      valkey_backup_restore_sidecar_image_name:
+        type: str
+        description: Image name of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      valkey_backup_restore_sidecar_image_tag:
+        type: str
+        description: Image tag of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.

--- a/control-plane/roles/valkey/tasks/main.yaml
+++ b/control-plane/roles/valkey/tasks/main.yaml
@@ -14,13 +14,6 @@
       - valkey_backup_restore_sidecar_encryption_key is none or valkey_backup_restore_sidecar_encryption_key | length == 32
       - valkey_backup_restore_sidecar_provider in ["local", "gcp", "s3"]
 
-- name: Check mandatory variables for this role are set
-  ansible.builtin.assert:
-    fail_msg: "not all mandatory variables given, check role documentation"
-    quiet: true
-    that:
-      - valkey_backup_restore_sidecar_image_tag is defined
-
 - name: Deploy valkey (backup-restore)
   kubernetes.core.k8s:
     definition: "{{ lookup('template', 'valkey.yaml') }}"

--- a/control-plane/roles/zitadel-db/meta/argument_specs.yaml
+++ b/control-plane/roles/zitadel-db/meta/argument_specs.yaml
@@ -1,0 +1,118 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys the zitadel database via the postgres-backup-restore role
+    options:
+      zitadel_db_name:
+        type: str
+        description: Name of the the zitadel db deployment.
+      zitadel_db_namespace:
+        type: str
+        description: The namespace to deploy the zitadel db to.
+      zitadel_db_image_pull_policy:
+        type: str
+        description: Image pull policy for the the zitadel db container.
+      zitadel_db_storage_size:
+        type: str
+        description: Size of the persistent volume.
+      zitadel_db_storage_class:
+        type: str
+        description: Storage class of the persistent volume.
+      zitadel_db_db:
+        type: str
+        description: Name of the database to create.
+      zitadel_db_user:
+        type: str
+        description: User of the the zitadel db database.
+      zitadel_db_password:
+        type: str
+        no_log: true
+        description: Password of the the zitadel db database.
+      zitadel_db_max_connections:
+        type: raw
+        description: Maximum amount of database connections.
+      zitadel_db_backup_restore_sidecar_image_pull_policy:
+        type: str
+        description: Image pull policy for the backup-restore-sidecar container.
+      zitadel_db_backup_restore_sidecar_provider:
+        type: str
+        description: Backup provider used by the backup-restore-sidecar (local, gcp or s3).
+      zitadel_db_backup_restore_sidecar_backup_cron_schedule:
+        type: str
+        description: Cron schedule for creating backups.
+      zitadel_db_backup_restore_sidecar_log_level:
+        type: str
+        description: Log level of the backup-restore-sidecar.
+      zitadel_db_backup_restore_sidecar_object_prefix:
+        type: str
+        description: Object prefix used for backups in the object store.
+      zitadel_db_backup_restore_sidecar_object_max_keep:
+        type: raw
+        description: Maximum amount of backup objects to keep.
+      zitadel_db_backup_restore_sidecar_object_days_max_keep:
+        type: raw
+        description: Maximum age in days of backup objects to keep.
+      zitadel_db_backup_restore_sidecar_s3_request_checksum_calculation:
+        type: str
+        description: S3 request checksum calculation setting (e.g. when_required for non-AWS S3 endpoints).
+      zitadel_db_backup_restore_sidecar_encryption_key:
+        type: str
+        no_log: true
+        description: Encryption key (32 characters) for encrypting backups.
+      zitadel_db_backup_restore_sidecar_gcp_bucket_name:
+        type: str
+        description: GCP bucket name for storing backups.
+      zitadel_db_backup_restore_sidecar_gcp_backup_location:
+        type: str
+        description: GCP bucket location for storing backups.
+      zitadel_db_backup_restore_sidecar_gcp_project_id:
+        type: str
+        description: GCP project id of the backup bucket.
+      zitadel_db_backup_restore_sidecar_gcp_serviceaccount_json:
+        type: str
+        no_log: true
+        description: GCP service account JSON used for accessing the backup bucket.
+      zitadel_db_backup_restore_sidecar_s3_bucket_name:
+        type: str
+        description: S3 bucket name for storing backups.
+      zitadel_db_backup_restore_sidecar_s3_region:
+        type: str
+        description: S3 region of the backup bucket.
+      zitadel_db_backup_restore_sidecar_s3_endpoint:
+        type: str
+        description: S3 endpoint of the backup bucket.
+      zitadel_db_backup_restore_sidecar_s3_access_key:
+        type: str
+        description: S3 access key for the backup bucket.
+      zitadel_db_backup_restore_sidecar_s3_secret_key:
+        type: str
+        no_log: true
+        description: S3 secret key for the backup bucket.
+      zitadel_db_backup_restore_sidecar_s3_insecure_skip_verify:
+        type: raw
+        description: Whether to skip TLS certificate verification for the S3 endpoint.
+      zitadel_db_backup_restore_sidecar_s3_trusted_ca_cert:
+        type: str
+        description: Trusted CA certificate for the S3 endpoint.
+      zitadel_db_resources:
+        type: dict
+        description: Resource requests and limits for the the zitadel db container.
+      zitadel_db_registry_auth_enabled:
+        type: raw
+        description: Whether to deploy an image pull secret for the registry.
+      zitadel_db_registry_auth:
+        type: dict
+        no_log: true
+        description: Docker auth configuration for the image pull secret.
+      zitadel_db_image_name:
+        type: str
+        description: Image name of the zitadel db. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      zitadel_db_image_tag:
+        type: str
+        description: Image tag of the zitadel db. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      zitadel_db_backup_restore_sidecar_image_name:
+        type: str
+        description: Image name of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      zitadel_db_backup_restore_sidecar_image_tag:
+        type: str
+        description: Image tag of the backup-restore-sidecar. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.

--- a/control-plane/roles/zitadel/meta/argument_specs.yaml
+++ b/control-plane/roles/zitadel/meta/argument_specs.yaml
@@ -1,0 +1,88 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys Zitadel as OIDC provider for the metal-stack control plane
+    options:
+      zitadel_chart_version:
+        type: str
+        description: Version of the zitadel helm chart. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      zitadel_chart_repo:
+        type: str
+        description: Repository URL of the zitadel helm chart. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      zitadel_image_tag:
+        type: str
+        description: Image tag of zitadel. Uses the chart default when unset.
+      zitadel_init_image_name:
+        type: str
+        description: Image name of the zitadel-metal-init job. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      zitadel_init_image_tag:
+        type: str
+        description: Image tag of the zitadel-metal-init job. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      zitadel_tools_kubectl_tag:
+        type: str
+        description: Image tag of the kubectl image used by the init job.
+      zitadel_endpoint:
+        type: str
+        description: The zitadel endpoint host name.
+      zitadel_namespace:
+        type: str
+        description: The namespace to deploy zitadel to.
+      zitadel_external_domain:
+        type: str
+        required: true
+        description: The external domain configured for the zitadel instance.
+      zitadel_ingress_dns:
+        type: str
+        description: The external URL of the zitadel ingress.
+      zitadel_ingress_annotations:
+        type: dict
+        description: Additional annotations for the zitadel ingress.
+      zitadel_port:
+        type: int
+        description: The port of the zitadel service.
+      zitadel_skip_verify_tls:
+        type: bool
+        description: Whether the init job skips TLS certificate verification.
+      zitadel_insecure:
+        type: bool
+        description: Whether zitadel runs in insecure (http) mode.
+      zitadel_tls_enabled:
+        type: bool
+        description: Whether TLS is enabled on the zitadel ingress.
+      zitadel_initial_instance:
+        type: str
+        description: Name of the initial zitadel instance.
+      zitadel_initial_org:
+        type: str
+        description: Name of the initial zitadel organization.
+      zitadel_admin_password:
+        type: str
+        no_log: true
+        description: Password of the initial zitadel admin user.
+      zitadel_master_key:
+        type: str
+        no_log: true
+        description: The zitadel master key (32 characters).
+      zitadel_db_address:
+        type: str
+        description: Address of the zitadel database.
+      zitadel_db_password:
+        type: str
+        no_log: true
+        description: Password of the zitadel database.
+      zitadel_enabled_ingress:
+        type: bool
+        description: Whether to create an ingress for zitadel.
+      zitadel_httproute_enabled:
+        type: bool
+        description: Whether to expose zitadel through a GatewayAPI HTTPRoute instead of an ingress.
+      zitadel_httproute_parent_refs:
+        type: list
+        elements: dict
+        description: Parent references for the zitadel HTTPRoute.
+      zitadel_init_config:
+        type: dict
+        description: Configuration for the zitadel-metal-init job (static users, project, application, generic OIDC providers).
+      zitadel_image_pull_policy:
+        type: str
+        description: Image pull policy for the zitadel containers.

--- a/partition/roles/alloy/meta/argument_specs.yaml
+++ b/partition/roles/alloy/meta/argument_specs.yaml
@@ -1,0 +1,66 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys Grafana Alloy in a systemd-managed Docker container
+    options:
+      alloy_image_name:
+        type: str
+        description: Image name of alloy. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      alloy_image_tag:
+        type: str
+        description: Image tag of alloy. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      alloy_config_host_dir:
+        type: str
+        description: The location of the alloy config on the host.
+      alloy_docker_log_driver:
+        type: str
+        description: Docker log driver for the alloy container.
+      alloy_loki_write_endpoints:
+        type: list
+        elements: dict
+        description: List of Loki push endpoints. Each entry supports url, remote_timeout and basic_auth (username, password). Required unless alloy_config_raw is set.
+      alloy_config_snippets:
+        type: list
+        elements: str
+        description: "List of built-in snippet names to enable. Available: syslog, journal, journal-file, docker, alloy-meta."
+      alloy_config_custom_snippets:
+        type: list
+        elements: str
+        description: List of paths to custom Alloy River snippet templates, resolved via Ansible's template search path. Appended after built-in snippets.
+      alloy_config_raw:
+        type: str
+        description: Full Alloy River config as a string. When set, bypasses snippet assembly entirely.
+      alloy_port:
+        type: int
+        description: Port for Alloy metrics and HTTP API.
+      alloy_migrate_from_promtail:
+        type: bool
+        description: Enable migration mode that imports cursor state from the legacy promtail positions file on first start.
+      alloy_syslog_legacy_positions_file:
+        type: str
+        description: Path to the legacy promtail positions file used by the syslog snippet during migration.
+      alloy_journal_path:
+        type: str
+        description: Path to the persistent journal directory used by the journal-file snippet.
+      alloy_journal_legacy_positions_file:
+        type: str
+        description: Path to the legacy promtail positions file used by the journal-file snippet during migration.
+      alloy_journal_legacy_position_name:
+        type: str
+        description: Job name from the old promtail journal scrape_config. Required when alloy_migrate_from_promtail is true and the journal-file snippet is used.
+      alloy_docker_network:
+        type: str
+        description: The docker network to launch the alloy container in.
+      alloy_docker_security_opts:
+        type: list
+        elements: str
+        description: Additional security opts passed to the docker container.
+      promtail_migrate_stop:
+        type: bool
+        description: Stop and disable the promtail systemd service during alloy cutover. Implied by promtail_migrate_cleanup.
+      promtail_migrate_cleanup:
+        type: bool
+        description: Remove all promtail remnants (service, unit file, config directory, positions files). Only set once migration to alloy is fully complete.
+      promtail_config_host_dir:
+        type: str
+        description: The promtail config directory removed when promtail_migrate_cleanup is enabled (defined by the deprecated promtail role).

--- a/partition/roles/dhcp-relay/meta/argument_specs.yaml
+++ b/partition/roles/dhcp-relay/meta/argument_specs.yaml
@@ -1,0 +1,12 @@
+---
+argument_specs:
+  main:
+    short_description: Configures DHCP relaying on Cumulus switches
+    options:
+      dhcp_relay_interface:
+        type: str
+        description: The interface to relay DHCP requests from.
+      dhcp_relay_server:
+        type: raw
+        required: true
+        description: The DHCP server (string) or servers (list of strings) to relay requests to.

--- a/partition/roles/dhcp/meta/argument_specs.yaml
+++ b/partition/roles/dhcp/meta/argument_specs.yaml
@@ -1,0 +1,37 @@
+---
+argument_specs:
+  main:
+    short_description: Installs and configures the isc-dhcp-server
+    options:
+      dhcp_subnets:
+        type: list
+        elements: dict
+        description: DHCP subnets to serve. Each entry supports comment, network, netmask, range (begin, end) and options.
+      dhcp_listening_interfaces:
+        type: list
+        elements: str
+        description: Interfaces the DHCP server listens on.
+      dhcp_default_lease_time:
+        type: int
+        description: Default lease time in seconds.
+      dhcp_max_lease_time:
+        type: int
+        description: Maximum lease time in seconds.
+      dhcp_global_options:
+        type: list
+        elements: str
+        description: Global options rendered into dhcpd.conf.
+      dhcp_global_deny_list:
+        type: list
+        elements: str
+        description: Global deny statements rendered into dhcpd.conf (e.g. unknown-clients).
+      dhcp_service_name:
+        type: str
+        description: Name of the DHCP server service.
+      dhcp_static_hosts:
+        type: list
+        elements: dict
+        description: Static host declarations. Each entry supports name, mac and ip.
+      dhcp_use_host_decl_names:
+        type: bool
+        description: Whether to enable use-host-decl-names in dhcpd.conf.

--- a/partition/roles/frr/meta/argument_specs.yaml
+++ b/partition/roles/frr/meta/argument_specs.yaml
@@ -1,0 +1,15 @@
+---
+argument_specs:
+  main:
+    short_description: Installs and configures FRR
+    options:
+      frr_version:
+        type: str
+        description: The FRR version to install.
+      frr_repo:
+        type: str
+        description: The FRR repository to install from.
+      frr_conf:
+        type: str
+        required: true
+        description: The complete frr.conf content to deploy.

--- a/partition/roles/image-cache/meta/argument_specs.yaml
+++ b/partition/roles/image-cache/meta/argument_specs.yaml
@@ -1,0 +1,122 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys a partition-local image cache (CoreDNS, haproxy and metal-image-cache-sync)
+    options:
+      image_cache_coredns_image_name:
+        type: str
+        description: Image name of CoreDNS. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      image_cache_coredns_image_tag:
+        type: str
+        description: Image tag of CoreDNS. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      image_cache_haproxy_image_name:
+        type: str
+        description: Image name of haproxy. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      image_cache_haproxy_image_tag:
+        type: str
+        description: Image tag of haproxy. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      image_cache_sync_image_name:
+        type: str
+        description: Image name of metal-image-cache-sync. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      image_cache_sync_image_tag:
+        type: str
+        description: Image tag of metal-image-cache-sync. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      image_cache_intercept_domains:
+        type: list
+        elements: str
+        description: Domains for which DNS requests are intercepted and resolved to the image cache.
+      image_cache_kernel_cache_enabled:
+        type: bool
+        description: Whether to cache metal-hammer kernels.
+      image_cache_kernel_route_prefix:
+        type: str
+        description: HTTP route prefix under which cached kernels are served.
+      image_cache_boot_image_cache_enabled:
+        type: bool
+        description: Whether to cache metal-hammer boot images.
+      image_cache_boot_image_route_prefix:
+        type: str
+        description: HTTP route prefix under which cached boot images are served.
+      image_cache_external_dns_servers:
+        type: list
+        elements: dict
+        description: External DNS servers (name, ip) used for forwarding non-intercepted DNS requests.
+      image_cache_backend_hosts:
+        type: list
+        elements: str
+        description: The hosts serving as image cache backends.
+      image_cache_internal_ip:
+        type: str
+        description: Alternative IP (default is ansible_host) used for resolving DNS requests to image cache hosts and for internal component communication.
+      image_cache_coredns_host_dir_path:
+        type: str
+        description: Host directory for the CoreDNS configuration.
+      image_cache_coredns_docker_log_driver:
+        type: str
+        description: Docker log driver for the CoreDNS container.
+      image_cache_haproxy_host_dir_path:
+        type: str
+        description: Host directory for the haproxy configuration.
+      image_cache_haproxy_docker_log_driver:
+        type: str
+        description: Docker log driver for the haproxy container.
+      image_cache_sync_max_cache_size:
+        type: str
+        description: Maximum size of the image cache (e.g. 100G).
+      image_cache_sync_max_images_per_name:
+        type: int
+        description: Maximum amount of images to keep per image name (-1 for unlimited).
+      image_cache_sync_min_images_per_name:
+        type: int
+        description: Minimum amount of images to keep per image name.
+      image_cache_sync_expiration_grace_period:
+        type: int
+        description: Grace period for expired images before removal from the cache.
+      image_cache_sync_metal_api_endpoint:
+        type: str
+        description: The metal-api endpoint used for looking up images to sync.
+      image_cache_sync_metal_api_view_hmac:
+        type: str
+        required: true
+        no_log: true
+        description: The metal-api view HMAC used for authenticating against the metal-api.
+      image_cache_sync_schedule:
+        type: str
+        description: Cron schedule for the image sync.
+      image_cache_sync_host_path:
+        type: str
+        description: Host path where synced images are stored.
+      image_cache_sync_port:
+        type: int
+        description: Port on which cached OS images are served.
+      image_cache_sync_kernel_port:
+        type: int
+        description: Port on which cached kernels are served.
+      image_cache_sync_boot_image_port:
+        type: int
+        description: Port on which cached boot images are served.
+      image_cache_sync_excludes:
+        type: list
+        elements: str
+        description: Image path substrings excluded from syncing.
+      image_cache_sync_docker_log_driver:
+        type: str
+        description: Docker log driver for the image sync container.
+      image_cache_haproxy_fallback_backend_server:
+        type: str
+        description: Fallback backend server (must be reachable over https with a valid certificate) used when the local image cache is unavailable.
+      image_cache_haproxy_fallback_backend_server_health_endpoint:
+        type: str
+        description: Health check endpoint of the fallback backend server.
+      image_cache_haproxy_kernel_fallback_backend_server:
+        type: str
+        description: Fallback backend server for kernels.
+      image_cache_haproxy_kernel_fallback_backend_server_health_endpoint:
+        type: str
+        description: Health check endpoint of the kernel fallback backend server.
+      image_cache_haproxy_boot_image_fallback_backend_server:
+        type: str
+        description: Fallback backend server for boot images.
+      image_cache_haproxy_boot_image_fallback_backend_server_health_endpoint:
+        type: str
+        description: Health check endpoint of the boot image fallback backend server.

--- a/partition/roles/lvm/meta/argument_specs.yaml
+++ b/partition/roles/lvm/meta/argument_specs.yaml
@@ -1,0 +1,19 @@
+---
+argument_specs:
+  main:
+    short_description: Manages a server's disks with LVM
+    options:
+      lvm_vg:
+        type: str
+        required: true
+        description: The volume group to be created and managed.
+      lvm_pvs:
+        type: list
+        elements: str
+        required: true
+        description: The physical disks that should be managed.
+      lvm_lvs:
+        type: list
+        elements: dict
+        required: true
+        description: The logical volumes to create. Each entry supports name, size, fstype, mountpath and optionally opts.

--- a/partition/roles/lvm/tasks/main.yaml
+++ b/partition/roles/lvm/tasks/main.yaml
@@ -1,13 +1,4 @@
 ---
-- name: Check mandatory variables for this role are set
-  ansible.builtin.assert:
-    fail_msg: "not all mandatory variables given, check role documentation"
-    quiet: true
-    that:
-      - lvm_vg is not none
-      - lvm_pvs is not none
-      - lvm_lvs is not none
-
 - name: Create volumegroup
   community.general.lvg:
     vg: "{{ lvm_vg }}"

--- a/partition/roles/metal-bmc/meta/argument_specs.yaml
+++ b/partition/roles/metal-bmc/meta/argument_specs.yaml
@@ -1,0 +1,89 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys metal-bmc in a systemd-managed Docker container
+    options:
+      metal_bmc_image_name:
+        type: str
+        description: Image name of metal-bmc. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_bmc_image_tag:
+        type: str
+        description: Image tag of metal-bmc. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_bmc_nsqd_addr:
+        type: str
+        required: true
+        description: Address (host:port) of the nsqd instance to connect to.
+      metal_bmc_bmc_superuser:
+        type: str
+        required: true
+        description: The IPMI superuser name used to access the machine BMCs.
+      metal_bmc_bmc_superuser_pwd:
+        type: str
+        required: true
+        no_log: true
+        description: The IPMI superuser password used to access the machine BMCs.
+      metal_bmc_ignore_macs:
+        type: list
+        elements: str
+        description: MAC addresses ignored by metal-bmc.
+      metal_bmc_allowed_cidrs:
+        type: list
+        elements: str
+        description: CIDRs from which BMCs are allowed to be reported.
+      metal_bmc_nsq_log_level:
+        type: str
+        description: Log level for nsq communication.
+      metal_bmc_nsq_tls_enabled:
+        type: bool
+        description: Whether TLS is used for the nsqd connection. When enabled, the nsqd certificate variables must be set.
+      metal_bmc_nsq_cert_dir:
+        type: str
+        description: Host directory where the nsq certificates are placed.
+      metal_bmc_nsqd_ca_cert:
+        type: str
+        description: The nsqd CA certificate content. Required when metal_bmc_nsq_tls_enabled is true.
+      metal_bmc_nsqd_client_cert:
+        type: str
+        description: The nsqd client certificate content. Required when metal_bmc_nsq_tls_enabled is true.
+      metal_bmc_nsqd_client_cert_key:
+        type: str
+        no_log: true
+        description: The nsqd client certificate key content. Required when metal_bmc_nsq_tls_enabled is true.
+      metal_bmc_console_port:
+        type: int
+        description: Port of the console proxy.
+      metal_bmc_console_cert_owner:
+        type: str
+        description: Owner of the console certificate files.
+      metal_bmc_console_cert_group:
+        type: str
+        description: Group of the console certificate files.
+      metal_bmc_console_cert_dir:
+        type: str
+        description: Host directory where the console certificates are placed.
+      metal_bmc_console_ca_cert:
+        type: str
+        required: true
+        description: The console CA certificate content.
+      metal_bmc_console_cert:
+        type: str
+        required: true
+        description: The console certificate content.
+      metal_bmc_console_key:
+        type: str
+        required: true
+        no_log: true
+        description: The console certificate key content.
+      metal_bmc_additional_volume_mounts:
+        type: list
+        elements: str
+        description: Additional volumes to mount into the metal-bmc container.
+      metal_bmc_docker_network:
+        type: str
+        description: The docker network to launch the metal-bmc container in.
+      metal_bmc_docker_log_driver:
+        type: str
+        description: Docker log driver for the metal-bmc container.
+      metal_bmc_lease_file:
+        type: str
+        description: Path to the DHCP lease file evaluated by metal-bmc.

--- a/partition/roles/metal-core/meta/argument_specs.yaml
+++ b/partition/roles/metal-core/meta/argument_specs.yaml
@@ -1,0 +1,88 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys metal-core in a systemd-managed Docker container
+    options:
+      metal_core_image_name:
+        type: str
+        description: Image name of metal-core. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_core_image_tag:
+        type: str
+        description: Image tag of metal-core. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      metal_core_cidr:
+        type: str
+        required: true
+        description: The CIDR of the switch used by metal-core (rendered into METAL_CORE_CIDR).
+      metal_core_rack_id:
+        type: str
+        required: true
+        description: The rack id describing the rack in which the leaf switches are contained.
+      metal_core_room_id:
+        type: str
+        description: The room id describing the room in which the rack is located.
+      metal_core_log_driver:
+        type: str
+        description: The log driver used for the metal-core container log.
+      metal_core_log_level:
+        type: str
+        description: The metal-core log level.
+      metal_core_hmac_key:
+        type: str
+        no_log: true
+        description: Legacy HMAC key variable, no longer rendered into the metal-core environment.
+      metal_core_reconfigure_switch:
+        type: bool
+        description: If set to true, metal-core will automatically reconfigure files on the switch.
+      metal_core_reconfigure_switch_interval:
+        type: str
+        description: The interval in which the switch config gets applied from information received from the metal-api.
+      metal_core_timeout:
+        type: str
+        description: The reconfigure timeout after which a reconfiguration run returns an error.
+      metal_core_set_src_loopback:
+        type: bool
+        description: If true, metal-core sets the default source address to loopback in frr.conf (SONiC only).
+      metal_core_grpc_address:
+        type: str
+        description: The address (host:port) of the metal-api gRPC server.
+      metal_core_grpc_cert_dir:
+        type: str
+        description: Path to the gRPC certificate files on the host machine.
+      metal_core_grpc_ca_cert:
+        type: str
+        description: The gRPC CA certificate content.
+      metal_core_grpc_client_cert:
+        type: str
+        description: The gRPC client certificate content.
+      metal_core_grpc_client_key:
+        type: str
+        no_log: true
+        description: The gRPC client certificate key content.
+      metal_core_additional_bridge_vids:
+        type: list
+        elements: str
+        description: Additional VLAN ids to add to the bridge.
+      metal_core_additional_bridge_ports:
+        type: list
+        elements: str
+        description: Additional ports to add to the bridge.
+      metal_core_spine_uplinks:
+        type: list
+        elements: str
+        description: The switch ports that connect a leaf to a spine switch or other ports that need to be part of the EVPN underlay fabric.
+      metal_core_additional_volume_mounts:
+        type: list
+        elements: str
+        description: Volumes to mount into metal-core, besides the default ones.
+      metal_core_consider_hosts_file_resolution:
+        type: bool
+        description: If set to true, mounts /etc/nsswitch.conf into the container to enable DNS resolution with the hosts file.
+      metal_core_interfaces_tpl_file:
+        type: str
+        description: The golang template file used for rendering /etc/network/interfaces. Empty uses the default template shipped with metal-core.
+      metal_core_frr_tpl_file:
+        type: str
+        description: The golang template file used for rendering /etc/frr/frr.conf. Empty uses the default template shipped with metal-core.
+      metal_core_pxe_vlan_id:
+        type: int
+        description: The VLAN ID for the PXE machines.

--- a/partition/roles/mgmt-firewall/meta/argument_specs.yaml
+++ b/partition/roles/mgmt-firewall/meta/argument_specs.yaml
@@ -1,0 +1,44 @@
+---
+argument_specs:
+  main:
+    short_description: Configures a Teltonika device as management firewall via uci
+    options:
+      mgmt_firewall_location_name:
+        type: str
+        required: true
+        description: The location name used for the system hostname and SNMP sysName.
+      mgmt_firewall_device_name:
+        type: str
+        required: true
+        description: The device name of the firewall.
+      mgmt_firewall_public_key:
+        type: str
+        required: true
+        description: The SSH public key written to the dropbear authorized_keys file.
+      mgmt_firewall_default_wan_enabled:
+        type: bool
+        description: Whether to configure the default WAN interface with a static address.
+      mgmt_firewall_static_routes_enabled:
+        type: bool
+        description: Whether to configure the static routes from mgmt_firewall_static_routes.
+      mgmt_firewall_wireless_disabled:
+        type: bool
+        description: Whether to disable the wireless radios.
+      mgmt_firewall_config:
+        type: dict
+        description: General firewall configuration including the bgp settings (enabled, general_ip, general_as, mgmtsrv_ipaddr, mgmtsrv_as).
+      mgmt_firewall_interfaces:
+        type: dict
+        description: LAN and WAN interface configuration (mgmt_firewall_lan list and mgmt_firewall_wan dict).
+      mgmt_firewall_port_forwards:
+        type: list
+        elements: dict
+        description: Port forward rules to apply.
+      mgmt_firewall_vlans:
+        type: list
+        elements: dict
+        description: Dynamic VLANs to configure (vlan, vid, ports).
+      mgmt_firewall_static_routes:
+        type: list
+        elements: dict
+        description: Static routes to configure (network, gateway).

--- a/partition/roles/mgmt-server/meta/argument_specs.yaml
+++ b/partition/roles/mgmt-server/meta/argument_specs.yaml
@@ -1,0 +1,73 @@
+---
+argument_specs:
+  main:
+    short_description: Configures a server to act as management server for a metal-stack partition
+    options:
+      mgmt_server_asn:
+        type: int
+        required: true
+        description: The ASN of the management server used for BGP.
+      mgmt_server_router_id:
+        type: str
+        required: true
+        description: The router-id to use for routing.
+      mgmt_server_spine_facing_interface:
+        type: str
+        required: true
+        description: The interface where the spine is connected at the management server.
+      mgmt_server_firewall_facing_interface:
+        type: str
+        description: The interface where the firewall is connected at the management server.
+      mgmt_server_firewall_ip:
+        type: str
+        description: The remote IP of the firewall for setting up a numbered BGP session.
+      mgmt_server_metal_ssh_privkey:
+        type: str
+        required: true
+        no_log: true
+        description: The SSH private key installed for the metal user.
+      mgmt_server_metal_ssh_pubkey:
+        type: str
+        required: true
+        description: The SSH public key installed for the metal user.
+      mgmt_server_metal_ssh_key_filename:
+        type: str
+        description: The filename under which the SSH key pair is stored in /home/metal/.ssh.
+      mgmt_server_metal_ssh_groups:
+        type: list
+        elements: str
+        description: The inventory hosts written to /etc/hosts and the metal user's ssh config.
+      mgmt_server_metal_ssh_options:
+        type: list
+        elements: str
+        description: Additional options rendered into the metal user's ssh config.
+      mgmt_server_registry_mirror:
+        type: str
+        description: The docker registry mirror to configure in the docker daemon.
+      mgmt_server_nameservers:
+        type: list
+        elements: str
+        description: The nameservers to use.
+      mgmt_server_dns_over_tls:
+        type: bool
+        description: Whether to enable DNS-over-TLS in systemd-resolved.
+      mgmt_server_frr_match_interfaces:
+        type: list
+        elements: str
+        description: Announce the networks attached to the given interfaces over BGP.
+      mgmt_server_frr_version:
+        type: str
+        description: The FRR version to use.
+      mgmt_server_frr_repo:
+        type: str
+        description: The FRR repository to use.
+      mgmt_server_frr_static_routes:
+        type: list
+        elements: str
+        description: Additional static routes rendered into frr.conf, e.g. "10.4.0.0/24 10.130.0.1".
+      mgmt_server_provide_default_route:
+        type: bool
+        description: Whether the management server announces a default route over BGP.
+      mgmt_server_preserve_dhcp_route:
+        type: bool
+        description: If set to true, DHCP routes are not flushed even when a BGP session to the firewall is configured.

--- a/partition/roles/mgmt-server/tasks/main.yaml
+++ b/partition/roles/mgmt-server/tasks/main.yaml
@@ -1,15 +1,4 @@
 ---
-- name: Check mandatory variables for this role are set
-  ansible.builtin.assert:
-    fail_msg: "not all mandatory variables given, check role documentation"
-    quiet: true
-    that:
-      - mgmt_server_asn is defined and mgmt_server_asn is not none
-      - mgmt_server_router_id is defined and mgmt_server_router_id is not none
-      - mgmt_server_spine_facing_interface is defined and mgmt_server_spine_facing_interface is not none
-      - mgmt_server_metal_ssh_privkey is defined and mgmt_server_metal_ssh_privkey is not none
-      - mgmt_server_metal_ssh_pubkey is defined and mgmt_server_metal_ssh_pubkey is not none
-
 - name: Gather package facts
   ansible.builtin.package_facts:
     manager: auto

--- a/partition/roles/monitoring/bgp-metrics/meta/argument_specs.yaml
+++ b/partition/roles/monitoring/bgp-metrics/meta/argument_specs.yaml
@@ -1,0 +1,11 @@
+---
+argument_specs:
+  main:
+    short_description: Installs a systemd timer that writes BGP metrics for the node-exporter textfile collector
+    options:
+      monitoring_bgp_metrics_textfile_directory:
+        type: str
+        description: The node-exporter textfile collector directory the metrics are written to.
+      monitoring_bgp_metrics_interval:
+        type: str
+        description: The interval in which the BGP metrics are collected.

--- a/partition/roles/monitoring/blackbox-exporter/meta/argument_specs.yaml
+++ b/partition/roles/monitoring/blackbox-exporter/meta/argument_specs.yaml
@@ -1,0 +1,20 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys the prometheus blackbox-exporter in a systemd-managed Docker container
+    options:
+      monitoring_blackbox_exporter_etc_host_dir:
+        type: str
+        description: Host directory for the blackbox-exporter configuration.
+      monitoring_blackbox_exporter_image_name:
+        type: str
+        description: Image name of the blackbox-exporter.
+      monitoring_blackbox_exporter_image_tag:
+        type: str
+        description: Image tag of the blackbox-exporter.
+      monitoring_blackbox_exporter_port:
+        type: int
+        description: Port the blackbox-exporter listens on.
+      monitoring_blackbox_exporter_docker_log_driver:
+        type: str
+        description: Docker log driver for the blackbox-exporter container.

--- a/partition/roles/monitoring/gnmic/meta/argument_specs.yaml
+++ b/partition/roles/monitoring/gnmic/meta/argument_specs.yaml
@@ -1,0 +1,77 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys gnmic on SONiC switches to collect telemetry via gNMI
+    options:
+      monitoring_gnmic_image_name:
+        type: str
+        description: Image name of gnmic. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      monitoring_gnmic_image_tag:
+        type: str
+        description: Image tag of gnmic. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      monitoring_gnmic_etc_host_dir:
+        type: str
+        description: Host directory for the gnmic configuration.
+      monitoring_gnmic_docker_log_driver:
+        type: str
+        description: Docker log driver for the gnmic container.
+      monitoring_gnmic_gnmi_address:
+        type: str
+        description: Address of the gNMI server on the switch.
+      monitoring_gnmic_gnmi_port:
+        type: int
+        description: Port of the gNMI server on the switch.
+      monitoring_gnmic_gnmi_username:
+        type: str
+        description: Username for the gNMI server.
+      monitoring_gnmic_gnmi_password:
+        type: str
+        no_log: true
+        description: Password for the gNMI server.
+      monitoring_gnmic_gnmi_insecure:
+        type: bool
+        description: Whether to connect to the gNMI server without TLS.
+      monitoring_gnmic_gnmi_skip_verify:
+        type: bool
+        description: Whether to skip TLS certificate verification for the gNMI server.
+      monitoring_gnmic_prometheus_port:
+        type: int
+        description: Port on which gnmic exposes prometheus metrics.
+      monitoring_gnmic_ports:
+        type: list
+        elements: str
+        description: Ports to subscribe to. Discovered from the switch at deploy time when left empty.
+      monitoring_gnmic_temperature_sensors:
+        type: list
+        elements: str
+        description: Temperature sensors to subscribe to. Discovered from the switch at deploy time when left empty.
+      monitoring_gnmic_fans:
+        type: list
+        elements: str
+        description: Fans to subscribe to. Discovered from the switch at deploy time when left empty.
+      monitoring_gnmic_crm_acl_tables:
+        type: list
+        elements: str
+        description: CRM ACL tables to subscribe to. Discovered from the switch at deploy time when left empty.
+      monitoring_gnmic_disabled_subscriptions:
+        type: list
+        elements: str
+        description: Subscription names (as defined in gnmic.yaml.j2) to disable.
+      monitoring_gnmic_sonic_distribution:
+        type: str
+        choices:
+          - broadcom
+          - edgecore
+        description: The SONiC distribution running on the switch.
+      monitoring_gnmic_sample_interval_counters:
+        type: str
+        description: Sample interval for counter subscriptions.
+      monitoring_gnmic_sample_interval_state:
+        type: str
+        description: Sample interval for state subscriptions.
+      monitoring_gnmic_sample_interval_config:
+        type: str
+        description: Sample interval for config subscriptions.
+      monitoring_gnmic_heartbeat_interval:
+        type: str
+        description: Heartbeat interval for on-change subscriptions.

--- a/partition/roles/monitoring/ipmi-exporter/meta/argument_specs.yaml
+++ b/partition/roles/monitoring/ipmi-exporter/meta/argument_specs.yaml
@@ -1,0 +1,31 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys the prometheus ipmi-exporter in a systemd-managed Docker container
+    options:
+      monitoring_ipmi_exporter_etc_host_dir:
+        type: str
+        description: Host directory for the ipmi-exporter configuration.
+      monitoring_ipmi_exporter_image_name:
+        type: str
+        description: Image name of the ipmi-exporter.
+      monitoring_ipmi_exporter_image_tag:
+        type: str
+        description: Image tag of the ipmi-exporter.
+      monitoring_ipmi_exporter_port:
+        type: int
+        description: Port the ipmi-exporter listens on.
+      monitoring_ipmi_exporter_docker_log_driver:
+        type: str
+        description: Docker log driver for the ipmi-exporter container.
+      monitoring_ipmi_bmc_superuser:
+        type: str
+        description: The IPMI superuser name used for scraping the machine BMCs.
+      monitoring_ipmi_bmc_superuser_pwd:
+        type: str
+        no_log: true
+        description: The IPMI superuser password used for scraping the machine BMCs.
+      monitoring_ipmi_exporter_collectors:
+        type: list
+        elements: str
+        description: The ipmi-exporter collectors to enable.

--- a/partition/roles/monitoring/ipmi-exporter/tasks/main.yaml
+++ b/partition/roles/monitoring/ipmi-exporter/tasks/main.yaml
@@ -1,12 +1,4 @@
 ---
-- name: Check mandatory variables for this role are set
-  ansible.builtin.assert:
-    fail_msg: "not all mandatory variables given, check role documentation"
-    quiet: true
-    that:
-      - monitoring_ipmi_bmc_superuser is defined
-      - monitoring_ipmi_bmc_superuser_pwd is defined
-
 - name: Create ipmi_exporter directories
   ansible.builtin.file:
     path: "{{ monitoring_ipmi_exporter_etc_host_dir }}"

--- a/partition/roles/monitoring/node-exporter/meta/argument_specs.yaml
+++ b/partition/roles/monitoring/node-exporter/meta/argument_specs.yaml
@@ -1,0 +1,23 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys the prometheus node-exporter in a systemd-managed Docker container
+    options:
+      monitoring_node_exporter_image_name:
+        type: str
+        description: Image name of the node-exporter.
+      monitoring_node_exporter_image_tag:
+        type: str
+        description: Image tag of the node-exporter.
+      monitoring_node_exporter_port:
+        type: int
+        description: Port the node-exporter listens on.
+      monitoring_node_exporter_dir:
+        type: str
+        description: Host directory used by the node-exporter.
+      monitoring_node_exporter_docker_log_driver:
+        type: str
+        description: Docker log driver for the node-exporter container.
+      monitoring_node_exporter_textfile_directory:
+        type: str
+        description: The textfile collector directory on the host.

--- a/partition/roles/monitoring/prometheus/meta/argument_specs.yaml
+++ b/partition/roles/monitoring/prometheus/meta/argument_specs.yaml
@@ -1,0 +1,124 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys prometheus for partition monitoring in a systemd-managed Docker container
+    options:
+      prometheus_image_name:
+        type: str
+        description: Image name of prometheus. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      prometheus_image_tag:
+        type: str
+        description: Image tag of prometheus. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      prometheus_port:
+        type: int
+        description: Port prometheus listens on.
+      prometheus_docker_log_driver:
+        type: str
+        description: Docker log driver for the prometheus container.
+      prometheus_scrape_interval:
+        type: str
+        description: The global scrape interval.
+      prometheus_evaluation_interval:
+        type: str
+        description: The global rule evaluation interval.
+      prometheus_scrape_timeout:
+        type: str
+        description: The global scrape timeout.
+      prometheus_ipmi_scrape_interval:
+        type: str
+        description: The scrape interval for the ipmi-exporter job.
+      prometheus_ipmi_scrape_timeout:
+        type: str
+        description: The scrape timeout for the ipmi-exporter job.
+      prometheus_config_host_dir:
+        type: str
+        description: Host directory for the prometheus configuration.
+      prometheus_data_host_dir:
+        type: str
+        description: Host directory for the prometheus data.
+      prometheus_alertmanager_target:
+        type: str
+        description: The alertmanager target (host:port) to send alerts to.
+      prometheus_alertmanager_basic_auth_username:
+        type: str
+        description: Basic auth username for the alertmanager.
+      prometheus_alertmanager_basic_auth_password:
+        type: str
+        no_log: true
+        description: Basic auth password for the alertmanager.
+      prometheus_remote_write:
+        type: list
+        elements: dict
+        description: Remote write configurations rendered into the prometheus configuration.
+      prometheus_remote_write_basic_auth_password:
+        type: str
+        no_log: true
+        description: Basic auth password that can be referenced from prometheus_remote_write entries.
+      prometheus_frr_exporter_targets:
+        type: list
+        elements: str
+        description: Scrape targets for the frr-exporter job.
+      prometheus_metal_core_targets:
+        type: list
+        elements: str
+        description: Scrape targets for the metal-core job.
+      prometheus_node_exporter_targets:
+        type: list
+        elements: str
+        description: Scrape targets for the node-exporter job.
+      prometheus_promtail_targets:
+        type: list
+        elements: str
+        description: Scrape targets for the promtail job.
+      prometheus_alloy_targets:
+        type: list
+        elements: str
+        description: Scrape targets for the alloy job.
+      prometheus_ping_targets:
+        type: list
+        elements: str
+        description: Targets for the blackbox-exporter icmp probes.
+      prometheus_ipmi_exporter_targets:
+        type: list
+        elements: str
+        description: Static scrape targets for the ipmi job. When empty, targets are generated dynamically from the DHCP leases via a systemd timer.
+      prometheus_sonic_exporter_targets:
+        type: list
+        elements: str
+        description: Scrape targets for the sonic-exporter job.
+      prometheus_gnmic_targets:
+        type: list
+        elements: str
+        description: Scrape targets for the gnmic job.
+      prometheus_blackbox_exporter_targets:
+        type: list
+        elements: str
+        description: Scrape targets for the blackbox-exporter job.
+      prometheus_lightbox_exporter_targets:
+        type: list
+        elements: str
+        description: Scrape targets for the lightbox-exporter job.
+      prometheus_lightos_smart_targets:
+        type: list
+        elements: str
+        description: Scrape targets for the lightos smart job.
+      prometheus_hosts_content:
+        type: str
+        description: Content of an /etc/hosts file mounted into the prometheus container for static name resolution.
+      prometheus_blackbox_exporter_icmp_groups:
+        type: list
+        elements: dict
+        description: Groups of icmp probe targets for the blackbox-exporter.
+      prometheus_blackbox_exporter_metal_api_probe_url:
+        type: str
+        description: The metal-api URL probed through the blackbox-exporter.
+      prometheus_haproxy_enabled:
+        type: bool
+        description: Whether the haproxy metrics job is scraped.
+      prometheus_blackbox_exporter_dns:
+        type: str
+        description: The DNS server probed through the blackbox-exporter.
+      prometheus_ipmi_exporter_allowed_cidrs:
+        type: list
+        elements: str
+        description: CIDRs from which dynamically discovered ipmi targets are allowed.

--- a/partition/roles/monitoring/sonic-exporter/meta/argument_specs.yaml
+++ b/partition/roles/monitoring/sonic-exporter/meta/argument_specs.yaml
@@ -1,0 +1,20 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys the sonic-exporter in a systemd-managed Docker container (deprecated, use gnmic instead)
+    options:
+      monitoring_sonic_exporter_image_name:
+        type: str
+        description: Image name of the sonic-exporter.
+      monitoring_sonic_exporter_image_tag:
+        type: str
+        description: Image tag of the sonic-exporter.
+      monitoring_sonic_exporter_address:
+        type: str
+        description: Address the sonic-exporter listens on.
+      monitoring_sonic_exporter_port:
+        type: int
+        description: Port the sonic-exporter listens on.
+      monitoring_sonic_exporter_docker_log_driver:
+        type: str
+        description: Docker log driver for the sonic-exporter container.

--- a/partition/roles/pixiecore/meta/argument_specs.yaml
+++ b/partition/roles/pixiecore/meta/argument_specs.yaml
@@ -1,0 +1,82 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys pixiecore in a systemd-managed Docker container
+    options:
+      pixiecore_image_name:
+        type: str
+        description: Image name of pixiecore. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      pixiecore_image_tag:
+        type: str
+        description: Image tag of pixiecore. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      pixiecore_api_host:
+        type: str
+        required: true
+        description: The host address on which the pixiecore API is reachable.
+      pixiecore_api_port:
+        type: int
+        description: The port on which the pixiecore API is served.
+      pixiecore_dns_servers:
+        type: list
+        elements: str
+        description: DNS servers passed to the pixiecore container.
+      pixiecore_partition_id:
+        type: str
+        description: The partition id passed to pixiecore.
+      pixiecore_debug:
+        type: bool
+        description: Whether to enable debug logging.
+      pixiecore_docker_log_driver:
+        type: str
+        description: Docker log driver for the pixiecore container.
+      pixiecore_grpc_address:
+        type: str
+        description: The address (host:port) of the metal-api gRPC server.
+      pixiecore_grpc_cert_dir:
+        type: str
+        description: Path to the gRPC certificate files on the host machine.
+      pixiecore_grpc_ca_cert:
+        type: str
+        description: The gRPC CA certificate content.
+      pixiecore_grpc_client_cert:
+        type: str
+        description: The gRPC client certificate content.
+      pixiecore_grpc_client_key:
+        type: str
+        no_log: true
+        description: The gRPC client certificate key content.
+      pixiecore_metal_api_url:
+        type: str
+        description: The metal-api URL passed to metal-hammer.
+      pixiecore_metal_api_hmac_view_key:
+        type: str
+        no_log: true
+        description: The metal-api view HMAC passed to metal-hammer.
+      pixiecore_metal_hammer_logging_endpoint:
+        type: str
+        description: Log forwarding endpoint for metal-hammer.
+      pixiecore_metal_hammer_logging_user:
+        type: str
+        description: Basic auth user for the metal-hammer logging endpoint.
+      pixiecore_metal_hammer_logging_password:
+        type: str
+        no_log: true
+        description: Basic auth password for the metal-hammer logging endpoint.
+      pixiecore_metal_hammer_logging_cert:
+        type: str
+        description: Client certificate content for the metal-hammer logging endpoint.
+      pixiecore_metal_hammer_logging_key:
+        type: str
+        no_log: true
+        description: Client certificate key content for the metal-hammer logging endpoint.
+      pixiecore_metal_hammer_logging_tls_insecure:
+        type: bool
+        description: Whether to skip TLS verification for the metal-hammer logging endpoint.
+      pixiecore_metal_hammer_ntp_servers:
+        type: list
+        elements: str
+        description: NTP servers passed to metal-hammer.
+      pixiecore_additional_volume_mounts:
+        type: list
+        elements: str
+        description: Additional volumes to mount into the pixiecore container.

--- a/partition/roles/promtail/meta/argument_specs.yaml
+++ b/partition/roles/promtail/meta/argument_specs.yaml
@@ -1,0 +1,25 @@
+---
+argument_specs:
+  main:
+    short_description: Deploys promtail in a systemd-managed Docker container (deprecated, use alloy instead)
+    options:
+      promtail_image_name:
+        type: str
+        description: Image name of promtail. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      promtail_image_tag:
+        type: str
+        description: Image tag of promtail. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      promtail_config_host_dir:
+        type: str
+        description: The location of the promtail config on the host.
+      promtail_clients:
+        type: list
+        elements: dict
+        description: Loki client configurations rendered into the promtail configuration. Must not be empty.
+      promtail_scrape_configs:
+        type: list
+        elements: dict
+        description: Scrape configs rendered into the promtail configuration. Must not be empty.
+      promtail_docker_log_driver:
+        type: str
+        description: Docker log driver for the promtail container.

--- a/partition/roles/sonic-config/meta/argument_specs.yaml
+++ b/partition/roles/sonic-config/meta/argument_specs.yaml
@@ -1,0 +1,107 @@
+---
+argument_specs:
+  main:
+    short_description: Generates the SONiC config_db and FRR configuration
+    options:
+      sonic_config_loopback_address:
+        type: str
+        required: true
+        description: The loopback (router) IP address of the switch.
+      sonic_config_asn:
+        type: int
+        description: The ASN of the switch used for BGP. Required when sonic_config_frr_render is true.
+      sonic_config_bgp_ports:
+        type: list
+        elements: str
+        description: The ports on which BGP unnumbered sessions are configured.
+      sonic_config_breakouts:
+        type: dict
+        description: Port breakout configuration keyed by port name.
+      sonic_config_docker_routing_config_mode:
+        type: str
+        description: The docker_routing_config_mode of the BGP container.
+      sonic_config_features:
+        type: dict
+        description: Feature flags rendered into the config_db.
+      sonic_config_frr_l2vpn_evpn:
+        type: bool
+        description: Whether to activate the l2vpn evpn address family.
+      sonic_config_frr_mgmt_framework_config:
+        type: bool
+        description: Whether the frr_mgmt_framework_config flag is set in the config_db.
+      sonic_config_frr_render:
+        type: bool
+        description: Whether to render and deploy the FRR configuration.
+      sonic_config_frr_set_source_address_loopback:
+        type: bool
+        description: Whether the loopback address is set as default BGP source address.
+      sonic_config_frr_route_map:
+        type: dict
+        description: Route map (name, match) used for redistributing connected routes.
+      sonic_config_frr_prefixlists:
+        type: list
+        description: Prefix lists rendered into frr.conf.
+      sonic_config_frr_static_routes:
+        type: list
+        elements: str
+        description: Static routes rendered into frr.conf.
+      sonic_config_frr_static_routes_mgmt:
+        type: list
+        elements: str
+        description: Static routes rendered into frr.conf for the management VRF.
+      sonic_config_frr_syslog_level:
+        type: str
+        description: The FRR syslog level.
+      sonic_config_interconnects:
+        type: dict
+        description: Interconnect BGP configuration.
+      sonic_config_lldp_hello_timer:
+        type: int
+        description: The LLDP hello timer in seconds.
+      sonic_config_mclag:
+        type: dict
+        description: MCLAG configuration.
+      sonic_config_mgmt_interface:
+        type: dict
+        description: Management interface configuration (ip, gateway).
+      sonic_config_mgmt_vrf:
+        type: bool
+        description: Whether the management interface is placed in the management VRF.
+      sonic_config_nameservers:
+        type: list
+        elements: str
+        description: Nameservers written to /etc/resolv.conf.
+      sonic_config_ntp:
+        type: dict
+        description: NTP configuration.
+      sonic_config_portchannels:
+        type: dict
+        description: Port channel configuration.
+      sonic_config_ports:
+        type: list
+        description: Physical port configuration.
+      sonic_config_reload_config:
+        type: bool
+        description: Whether the generated config_db is applied with config reload.
+      sonic_config_sag:
+        type: dict
+        description: Static anycast gateway configuration (mac).
+      sonic_config_ssh_sourceranges:
+        type: list
+        elements: str
+        description: Source ranges from which SSH access is allowed.
+      sonic_config_extended_cacl:
+        type: dict
+        description: Extended control plane ACLs (ipv4, ipv6 rule lists) rendered into iptables.json.
+      sonic_config_timezone:
+        type: str
+        description: The timezone to configure on the switch.
+      sonic_config_vlan_subinterfaces:
+        type: list
+        description: VLAN subinterface configuration.
+      sonic_config_vlans:
+        type: list
+        description: VLAN configuration.
+      sonic_config_vtep:
+        type: dict
+        description: VTEP configuration for EVPN.

--- a/partition/roles/sonic-upgrade/meta/argument_specs.yaml
+++ b/partition/roles/sonic-upgrade/meta/argument_specs.yaml
@@ -1,0 +1,24 @@
+---
+argument_specs:
+  main:
+    short_description: Upgrades the SONiC image on a switch
+    options:
+      sonic_upgrade_image:
+        type: str
+        required: true
+        description: The filename of the SONiC image to install.
+      sonic_upgrade_host:
+        type: str
+        description: The host serving the SONiC image over HTTP. Mutually exclusive with sonic_upgrade_image_path (exactly one must be set).
+      sonic_upgrade_image_path:
+        type: str
+        description: The directory on the switch containing the SONiC image. Mutually exclusive with sonic_upgrade_host (exactly one must be set).
+      sonic_upgrade_protocol:
+        type: str
+        description: The protocol used for downloading the image.
+      sonic_upgrade_port:
+        type: int
+        description: The port used for downloading the image.
+      sonic_upgrade_vrf:
+        type: str
+        description: The VRF in which the image download is executed.

--- a/partition/roles/sonic/meta/argument_specs.yaml
+++ b/partition/roles/sonic/meta/argument_specs.yaml
@@ -1,0 +1,141 @@
+---
+argument_specs:
+  main:
+    short_description: Configures SONiC switches (config_db and FRR)
+    options:
+      sonic_loopback_address:
+        type: str
+        required: true
+        description: The loopback (router) IP address of the switch.
+      sonic_asn:
+        type: raw
+        required: true
+        description: The ASN (integer) of the switch used for BGP. Only evaluated when sonic_frr_render is true.
+      sonic_mgmt_vrf:
+        type: bool
+        description: Whether the management interface is placed in the management VRF.
+      sonic_mgmtif_ip:
+        type: str
+        description: Static IP address (CIDR) of the management interface.
+      sonic_mgmtif_gateway:
+        type: str
+        description: Gateway of the management interface.
+      sonic_ntpservers:
+        type: list
+        elements: str
+        description: NTP servers to configure.
+      sonic_nameservers:
+        type: list
+        elements: str
+        description: Nameservers written to /etc/resolv.conf.
+      sonic_ip_masquerade:
+        type: bool
+        description: Whether to activate IP masquerading on eth0.
+      sonic_timezone:
+        type: str
+        description: The timezone to configure on the switch.
+      sonic_config_action:
+        type: str
+        choices:
+          - load
+          - reload
+        description: Whether the generated config_db is applied with config load or config reload.
+      sonic_render_config_db_template:
+        type: bool
+        description: Whether to render and save the config_db from the template.
+      sonic_ports:
+        type: list
+        elements: dict
+        description: Physical port configuration. Each entry supports name and optionally speed, mtu and fec.
+      sonic_ports_dict:
+        type: dict
+        description: Port configuration keyed by port name. Populated from sonic_ports if left empty.
+      sonic_ports_default_fec:
+        type: str
+        description: Default FEC for ports that do not specify one.
+      sonic_ports_default_speed:
+        type: int
+        description: Default speed for ports that do not specify one. Required when sonic_ports is non-empty.
+      sonic_ports_default_mtu:
+        type: int
+        description: Default MTU for ports that do not specify one. Required when sonic_ports is non-empty.
+      sonic_breakouts:
+        type: dict
+        description: Port breakout configuration keyed by port name.
+      sonic_portchannels:
+        type: list
+        elements: dict
+        description: Port channel configuration.
+      sonic_portchannels_default_mtu:
+        type: int
+        description: Default MTU for port channels. Required when sonic_portchannels is non-empty.
+      sonic_bgp_ports:
+        type: list
+        elements: str
+        description: The ports on which BGP unnumbered sessions are configured.
+      sonic_frr_render:
+        type: bool
+        description: Whether to render and deploy the FRR configuration.
+      sonic_frr_debug_options:
+        type: list
+        elements: str
+        description: FRR debug options rendered into frr.conf.
+      sonic_frr_syslog_level:
+        type: str
+        description: The FRR syslog level.
+      sonic_frr_l2vpn_evpn:
+        type: bool
+        description: Whether to activate the l2vpn evpn address family.
+      sonic_frr_route_map:
+        type: dict
+        description: Route map (name, match) used for redistributing connected routes.
+      sonic_frr_static_routes:
+        type: list
+        elements: str
+        description: Static routes rendered into frr.conf.
+      sonic_frr_static_routes_mgmt:
+        type: list
+        elements: str
+        description: Static routes rendered into frr.conf for the management VRF.
+      sonic_vlan_members:
+        type: bool
+        description: Whether VLAN members are rendered into the config_db.
+      sonic_vlans:
+        type: list
+        elements: dict
+        description: VLAN configuration. Each entry supports id, ip, untagged_ports and dhcp_servers.
+      sonic_vteps:
+        type: list
+        elements: dict
+        description: VTEP configuration for EVPN.
+      sonic_lldp_hello_timer:
+        type: int
+        description: The LLDP hello timer in seconds.
+      sonic_docker_routing_config_mode:
+        type: str
+        description: The docker_routing_config_mode of the BGP container.
+      sonic_frr_mgmt_framework_config:
+        type: bool
+        description: Whether the frr_mgmt_framework_config flag is set in the config_db.
+      sonic_mclag:
+        type: dict
+        description: MCLAG configuration.
+      sonic_sag:
+        type: dict
+        description: Static anycast gateway configuration (mac).
+      sonic_ssh_sourceranges:
+        type: list
+        elements: str
+        description: Source ranges from which SSH access is allowed.
+      sonic_extended_cacl:
+        type: dict
+        description: Extended control plane ACLs (ipv4, ipv6 rule lists) rendered into iptables.json.
+      sonic_interconnects:
+        type: dict
+        description: Interconnect BGP configuration.
+      sonic_interconnects_default_peer_group:
+        type: str
+        description: Default peer group for interconnects.
+      sonic_interconnects_default_bgp_timers:
+        type: str
+        description: Default BGP timers for interconnects.

--- a/partition/roles/systemd-networkd/meta/argument_specs.yaml
+++ b/partition/roles/systemd-networkd/meta/argument_specs.yaml
@@ -1,0 +1,24 @@
+---
+argument_specs:
+  main:
+    short_description: Configures networking with systemd-networkd
+    options:
+      systemd_networkd_mtu:
+        type: int
+        description: The default MTU configured on the interfaces.
+      systemd_networkd_nics:
+        type: list
+        elements: dict
+        description: The physical NICs to configure.
+      systemd_networkd_vrfs:
+        type: list
+        elements: dict
+        description: The VRFs to configure.
+      systemd_networkd_vlans:
+        type: list
+        elements: dict
+        description: The VLANs to configure.
+      systemd_networkd_vxlans:
+        type: list
+        elements: dict
+        description: The VXLANs to configure.

--- a/partition/roles/wireguard/meta/argument_specs.yaml
+++ b/partition/roles/wireguard/meta/argument_specs.yaml
@@ -1,0 +1,32 @@
+---
+argument_specs:
+  main:
+    short_description: Installs and configures a wireguard server
+    options:
+      wireguard_ip:
+        type: str
+        required: true
+        description: The wireguard server address (CIDR) configured on the wg0 interface.
+      wireguard_public_key:
+        type: str
+        description: Pre-generated wireguard public key. When unset, a key pair is generated on the host.
+      wireguard_private_key:
+        type: str
+        no_log: true
+        description: Pre-generated wireguard private key. When unset, a key pair is generated on the host.
+      wireguard_cert_directory:
+        type: str
+        description: Directory in which the wireguard keys are stored.
+      wireguard_cert_owner:
+        type: str
+        description: Owner of the wireguard key directory.
+      wireguard_cert_group:
+        type: str
+        description: Group of the wireguard key directory.
+      wireguard_listen_port:
+        type: int
+        description: The port the wireguard server listens on.
+      wireguard_clients:
+        type: list
+        elements: dict
+        description: Wireguard clients to configure. Each entry supports name, public_key and client_id.

--- a/partition/roles/ztp/meta/argument_specs.yaml
+++ b/partition/roles/ztp/meta/argument_specs.yaml
@@ -1,0 +1,34 @@
+---
+argument_specs:
+  main:
+    short_description: Serves zero touch provisioning files for SONiC switches via nginx
+    options:
+      ztp_nginx_image_name:
+        type: str
+        description: Image name of nginx. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      ztp_nginx_image_tag:
+        type: str
+        description: Image tag of nginx. Resolved from the metal-stack release vector via setup_yaml when not set explicitly.
+      ztp_authorized_keys:
+        type: str
+        required: true
+        description: The authorized_keys content installed for the admin user during provisioning.
+      ztp_admin_user:
+        type: str
+        description: The admin user created during provisioning.
+      ztp_host_dir_path:
+        type: str
+        description: Host directory from which the ZTP files are served.
+      ztp_listen_address:
+        type: str
+        description: The address on which the ZTP files are served.
+      ztp_port:
+        type: int
+        description: The port on which the ZTP files are served.
+      ztp_additional_files:
+        type: list
+        elements: dict
+        description: Additional files (name, data) to serve. Must not contain a file named user.sh.
+      ztp_nginx_docker_log_driver:
+        type: str
+        description: Docker log driver for the nginx container.


### PR DESCRIPTION

## Add role argument specs for typed variable validation

Ansible validates nothing about role variables by default: a typo'd optional variable is silently ignored, a string where a list is expected fails deep inside a template, and "mandatory" is only enforced where a hand-written assert happens to exist. This PR adds `meta/argument_specs.yaml` to every role (55 specs: partition, control-plane, common), so every variable is declared with a type, a description, and (where enforceable) `required: true`, validated by ansible before the first task runs. As a side effect, `ansible-doc` can now render per-role documentation from the specs.

### Design decisions

- **`required: true` is presence-based.** Empirically (ansible-core 2.21), a variable declared as `None` in defaults *satisfies* `required: true`, so requiredness is only truly enforced for variables with no defaults entry. None-defaulted-but-asserted variables are still marked required as documentation of intent; their runtime asserts remain the enforcement.
- **Release-vector variables are never `required`.** Image/chart variables resolved from `metal_stack_release.mapping` are set by `setup_yaml` at task time; *after* spec validation runs. Their specs note the resolution in the description instead. Asserts guarding them are kept.
- **Asserts were only removed where the spec fully replaces them** (6 pure presence-check blocks, two of which were literal duplicates). All richer asserts (value choices, XOR/conditional checks, placeholder checks, release-vector checks) are kept.
- **No `suboptions` on list/dict variables** unknown suboption keys would hard-fail existing inventories; structures stay loosely typed for now. **Secrets** (passwords, HMAC keys, private keys) carry `no_log: true`.
- Int/bool-typed variables that legitimately pass through as `None` are declared `raw` (type conversion rejects None, unlike str/list/dict).

### Verification

- All 55 specs load through ansible's `ArgumentSpecValidator`; each role's own defaults validate against its spec; every defaults key is covered.
- Running a role without its required variables fails with `missing required arguments: ...` before any task executes.
- [ ] TODO would be to run this version on actual hardware. I can use Fundament POC for all the roles we use there, but haven't done that yet.

### Changes that I think we should discuss

- Newly *enforced*. These have no default and no prior assert, but we probably should confirm deployments set them: `metal_core_cidr`; `metal_api_grpc_certs_{ca_cert,server_cert, server_key}`, `metal_masterdata_api_tls_*` and `headscale_noise_private_key`.
- `metal_api_grpc_certs_{ca_cert,server_cert,server_key}` are marked `required: true`. This codifies existing behavior rather than adding a new constraint: `metal-values.j2` renders these three values unconditionally (`| b64encode` fails on undefined), so every deployment must already define them, even with `metal_api_grpc_tls_enabled: false`, since the toggle is not used as a guard in the template. The spec just moves the failure from a mid-template error to a clear "missing required arguments" at role start. Probably `metal_api_grpc_tls_enabled` should be removed as it is currently unsable? But didn't want to scope-creep this (already huge) PR.
- Spec validation templates listed defaults at role start, so a few `lookup('k8s', ...)` defaults in the metal/monitoring roles evaluate slightly earlier than before (same role execution, earlier moment).
- Type declarations worth a second opinion: `mgmt_server_asn: int` (breaks dotted ASN notation), `dhcp_relay_server: raw` (string-or-list), sonic port speed/MTU ints.
- Found that `metal_core_hmac_key` appears unused and `mgmt_server_firewall_facing_interface` was documented as mandatory but no longer consumed (declared optional). Can we remove both?
- Also closed a gap: `metal_apiserver_image_name/tag` and `metal_metrics_exporter_image_name/tag` were rendered unguarded but missing from their roles' release-vector assert blocks. New checks added there, since argument_specs cannot enforce release-vector variables (see design decisions).

#### Used AI

Claude Fable 5