### PR TITLE
lint: fix no-changed-when and schema violations and enforce them

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -10,9 +10,8 @@ exclude_paths:
   # these are template results, so they do not need formatting:
   - partition/roles/sonic/test/data/**/metal.yaml
 
-# TODO: we need to gradually fix these!
+# role-name and var-naming are intentionally kept as warnings because renaming
+# roles or variables would break downstream consumers of these roles.
 warn_list:
   - role-name
-  - schema
   - var-naming
-  - no-changed-when

--- a/.yamllint
+++ b/.yamllint
@@ -18,8 +18,8 @@ rules:
   braces:
     min-spaces-inside: 0 # yamllint defaults to 0
     max-spaces-inside: 1 # yamllint defaults to 0
-  # key-duplicates:
-  #   forbid-duplicated-merge-keys: true # not enabled by default
+  key-duplicates:
+    forbid-duplicated-merge-keys: true # not enabled by default
   octal-values:
     forbid-implicit-octal: true # yamllint defaults to false
     forbid-explicit-octal: true # yamllint defaults to false

--- a/common/roles/metal-deployment-token/meta/main.yml
+++ b/common/roles/metal-deployment-token/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: metal-deployment-token
   author: metal-stack
   description: This role reads out an admin deployment token from the metal-apiserver and exports it in order to deploy infra services with it.
   license: MIT

--- a/common/roles/metal-v2-client/meta/main.yaml
+++ b/common/roles/metal-v2-client/meta/main.yaml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: metal-v2-client
   author: metal-stack
   description: Installs the metal-stack v2 client library.
   license: MIT

--- a/control-plane/roles/auditing-timescaledb/meta/main.yml
+++ b/control-plane/roles/auditing-timescaledb/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: auditing-timescaledb
   author: metal-stack
   description: Deploys a timescaledb database for auditing.
   license: MIT

--- a/control-plane/roles/gardener-cloud-profile/meta/main.yml
+++ b/control-plane/roles/gardener-cloud-profile/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: gardener-cloud-profile
   author: metal-stack
   description: Deploys Gardener cloud profile for a metal-stack installation.
   license: MIT

--- a/control-plane/roles/gardener-extensions/meta/main.yml
+++ b/control-plane/roles/gardener-extensions/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: gardener-extensions
   author: metal-stack
   description: Deploys Gardener Extensions.
   license: MIT

--- a/control-plane/roles/gardener-gardenlet/meta/main.yml
+++ b/control-plane/roles/gardener-gardenlet/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: gardener-gardenlet
   author: metal-stack
   description: Deploys Gardener gardenlet through the operator.
   license: MIT

--- a/control-plane/roles/gardener-logging/meta/main.yaml
+++ b/control-plane/roles/gardener-logging/meta/main.yaml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: gardener-logging
   author: metal-stack
   description: Deploys Alloy into a Gardener seed.
   license: MIT

--- a/control-plane/roles/gardener-managed-seeds/meta/main.yml
+++ b/control-plane/roles/gardener-managed-seeds/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: gardener-managed-seeds
   author: metal-stack
   description: Deploys Gardener managed seeds.
   license: MIT

--- a/control-plane/roles/gardener-monitoring-certs/meta/main.yml
+++ b/control-plane/roles/gardener-monitoring-certs/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: gardener-monitoring-certs
   author: metal-stack
   description: Deploys certificates used for monitoring components of the Gardener.
   license: MIT

--- a/control-plane/roles/gardener-operator/meta/main.yml
+++ b/control-plane/roles/gardener-operator/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: gardener-operator
   author: metal-stack
   description: Deploys the Gardener operator.
   license: MIT

--- a/control-plane/roles/gardener-partition-proxy/meta/main.yml
+++ b/control-plane/roles/gardener-partition-proxy/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: gardener-partition-proxy
   author: metal-stack
   description: Deploys an nginx into a Gardener shooted seed to expose partition services.
   license: MIT

--- a/control-plane/roles/gardener-projects/meta/main.yml
+++ b/control-plane/roles/gardener-projects/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: gardener-projects
   author: metal-stack
   description: Deploys Gardener projects.
   license: MIT

--- a/control-plane/roles/gardener-shoots/meta/main.yml
+++ b/control-plane/roles/gardener-shoots/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: gardener-shoots
   author: metal-stack
   description: Deploys Gardener shoots.
   license: MIT

--- a/control-plane/roles/gardener-virtual-garden-access/meta/main.yml
+++ b/control-plane/roles/gardener-virtual-garden-access/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: gardener-virtual-garden-access
   author: metal-stack
   description: Deploys a managed resource for accessing the virtual garden.
   license: MIT

--- a/control-plane/roles/headscale/meta/main.yml
+++ b/control-plane/roles/headscale/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: headscale
   author: metal-stack
   description: Deploys headscalee for the metal-stack firewall VPN.
   license: MIT

--- a/control-plane/roles/ipam-db/meta/main.yml
+++ b/control-plane/roles/ipam-db/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: ipam-db
   author: metal-stack
   description: Deploys an ipam database for the go-ipam.
   license: MIT

--- a/control-plane/roles/isolated-clusters/meta/main.yml
+++ b/control-plane/roles/isolated-clusters/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: isolated-clusters
   author: metal-stack
   description: Deploys additional services for the isolated cluster feature.
   license: MIT

--- a/control-plane/roles/logging-common/meta/main.yaml
+++ b/control-plane/roles/logging-common/meta/main.yaml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: logging-common
   author: metal-stack
   description: Deploys logging components common to all environments
   license: MIT

--- a/control-plane/roles/logging/meta/main.yaml
+++ b/control-plane/roles/logging/meta/main.yaml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: logging
   author: metal-stack
   description: Deploys a logging stack for the metal-stack control plane.
   license: MIT

--- a/control-plane/roles/masterdata-db/meta/main.yaml
+++ b/control-plane/roles/masterdata-db/meta/main.yaml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: masterdata-db
   author: metal-stack
   description: Deploys a database for the masterdata-api.
   license: MIT

--- a/control-plane/roles/metal-db/meta/main.yaml
+++ b/control-plane/roles/metal-db/meta/main.yaml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: metal-db
   author: metal-stack
   description: Deploys a database for the metal-api.
   license: MIT

--- a/control-plane/roles/metal-python/meta/main.yaml
+++ b/control-plane/roles/metal-python/meta/main.yaml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: metal-python
   author: metal-stack
   description: Installs the metal-python client library.
   license: MIT

--- a/control-plane/roles/metal/meta/main.yml
+++ b/control-plane/roles/metal/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: metal
   author: metal-stack
   description: This role basically deploys the metal-control-plane.
   license: MIT

--- a/control-plane/roles/monitoring/meta/main.yaml
+++ b/control-plane/roles/monitoring/meta/main.yaml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: monitoring
   author: metal-stack
   description: Deploys a monitoring stack for the metal-stack control plane.
   license: MIT

--- a/control-plane/roles/nsq/meta/main.yml
+++ b/control-plane/roles/nsq/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: nsq
   author: metal-stack
   description: Deploys nsq in a standalone configuration.
   license: MIT

--- a/control-plane/roles/postgres-backup-restore/meta/main.yaml
+++ b/control-plane/roles/postgres-backup-restore/meta/main.yaml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: postgres-backup-restore
   author: metal-stack
   description: Deploys a postgres database including the backup-restore-sidecar container.
   license: MIT

--- a/control-plane/roles/prepare/meta/main.yaml
+++ b/control-plane/roles/prepare/meta/main.yaml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: prepare
   author: metal-stack
   description: Preparation tasks for the deployment of the metal-control-plane.
   license: MIT

--- a/control-plane/roles/rethinkdb-backup-restore/meta/main.yaml
+++ b/control-plane/roles/rethinkdb-backup-restore/meta/main.yaml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: rethinkdb-backup-restore
   author: metal-stack
   description: Deploys a rethinkdb database including the backup-restore-sidecar container.
   license: MIT

--- a/control-plane/roles/valkey/meta/main.yaml
+++ b/control-plane/roles/valkey/meta/main.yaml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: valkey
   author: metal-stack
   description: Deploys valkey into the control plane.
   license: MIT

--- a/control-plane/roles/zitadel-db/meta/main.yaml
+++ b/control-plane/roles/zitadel-db/meta/main.yaml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: zitadel-db
   author: metal-stack
   description: Deploys a database for the zitadel oidc provider.
   license: MIT

--- a/control-plane/roles/zitadel/meta/main.yaml
+++ b/control-plane/roles/zitadel/meta/main.yaml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: zitadel
   author: metal-stack
   description: Deploys zitadel into the control plane.
   license: MIT

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,9 +1,9 @@
 ---
 galaxy_info:
   author: metal-stack
-  company:
+  description: Ansible roles for deploying and operating metal-stack.
   license: "license (MIT)"
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   platforms:
     - name: Ubuntu
       versions:

--- a/partition/roles/alloy/meta/main.yml
+++ b/partition/roles/alloy/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: alloy
   author: metal-stack
   description: Deploys alloy.
   license: MIT

--- a/partition/roles/dhcp-relay/tasks/main.yaml
+++ b/partition/roles/dhcp-relay/tasks/main.yaml
@@ -10,9 +10,11 @@
 
 - name: Add dhcp relay interface
   ansible.builtin.command: net add dhcp relay interface {{ dhcp_relay_interface }}
+  changed_when: true
 
 - name: Remove priorly configured dhcp relay servers
   ansible.builtin.command: net del dhcp relay server
+  changed_when: true
 
 - name: Listify dhcp relays servers
   ansible.builtin.set_fact:
@@ -20,7 +22,9 @@
 
 - name: Add dhcp relay server
   ansible.builtin.command: net add dhcp relay server {{ item }}
+  changed_when: true
   loop: "{{ _dhcp_relay_servers }}"
 
 - name: Commit configuration
   ansible.builtin.command: net commit
+  changed_when: true

--- a/partition/roles/dhcp/meta/main.yml
+++ b/partition/roles/dhcp/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: dhcp
   author: metal-stack
   description: Configures and starts dhcpd.
   license: MIT

--- a/partition/roles/frr/handlers/main.yaml
+++ b/partition/roles/frr/handlers/main.yaml
@@ -11,3 +11,4 @@
 
 - name: Reload sysctls
   ansible.builtin.command: sysctl --system
+  changed_when: true

--- a/partition/roles/metal-bmc/meta/main.yml
+++ b/partition/roles/metal-bmc/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: metal-bmc
   author: metal-stack
   description: Deploys the metal-bmc.
   license: MIT

--- a/partition/roles/metal-core/meta/main.yml
+++ b/partition/roles/metal-core/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: metal-core
   author: metal-stack
   description: Deploys the metal-core.
   license: MIT
@@ -9,8 +8,8 @@ galaxy_info:
   platforms:
     - name: Cumulus
       versions:
-        - 3
-    - name: SONiC
+        - "3.0"
+    - name: Debian
       versions:
         - all
 

--- a/partition/roles/mgmt-firewall/tasks/main.yaml
+++ b/partition/roles/mgmt-firewall/tasks/main.yaml
@@ -20,6 +20,7 @@
     uci set bgp.general.as='{{ mgmt_firewall_config.bgp.general_as }}'
     uci set bgp.general.ebgp_requires_policy='1'
     uci set bgp.general.deterministic_med='0'
+  changed_when: true
   when: mgmt_firewall_config.bgp.enabled
 
 - name: Setup BGP Peer
@@ -32,6 +33,7 @@
     uci set bgp.mgmtsrv.enabled='1'
     uci commit bgp
     /etc/init.d/frr restart
+  changed_when: true
   when: mgmt_firewall_config.bgp.enabled
 
 - name: Setup SSH
@@ -44,6 +46,7 @@
     uci set firewall.15.enabled='1' # Enable SSH Wan
     uci commit firewall
     /etc/init.d/firewall
+  changed_when: true
 
 - name: Setup firewall default settings
   ansible.builtin.raw: |
@@ -66,28 +69,33 @@
     {% endif %}
     uci commit firewall
     /etc/init.d/firewall restart
+  changed_when: true
 
 - name: Get the total number of sms_utils rules
   ansible.builtin.raw: |
     uci show sms_utils | grep -o '@rule\[[0-9]\+\]' | sort -u | wc -l
   register: rule_count
+  changed_when: false
 
 - name: Disable all sms_utils rules
   ansible.builtin.raw: |
     uci set sms_utils.@rule[{{ item }}].enabled='0'
   loop: "{{ range(0, rule_count.stdout | int) }}"
   register: disable_output
+  changed_when: true
 
 - name: Commit and restart sms_utils after disabling rules
   ansible.builtin.raw: |
     uci commit sms_utils
     /etc/init.d/sms_utils restart
+  changed_when: true
 
 - name: Disable rms_connect
   ansible.builtin.raw: |
     uci set rms_mqtt.rms_connect_mqtt.enable='0'
     uci commit rms_mqtt
     /etc/init.d/rms_mqtt restart
+  changed_when: true
 
 - name: Change location Name
   ansible.builtin.raw: |
@@ -99,6 +107,7 @@
     uci commit snmpd
     uci commit system
     /etc/init.d/system restart
+  changed_when: true
 
 - name: Enable Remote Https Access
   ansible.builtin.raw: |
@@ -106,6 +115,7 @@
     uci set uhttpd.main.redirect_https='0'
     uci commit uhttpd
     /etc/init.d/uhttpd restart
+  changed_when: true
 
 - name: Disable wireless
   ansible.builtin.raw: |
@@ -113,11 +123,13 @@
     uci set wireless.default_radio0.disabled='1'
     uci commit wireless
     /etc/init.d/network restart
+  changed_when: true
   when: mgmt_firewall_wireless_disabled | default(true)
 
 - name: Create authorized keys file in /etc/dropbear
   ansible.builtin.raw: |
     echo '{{ mgmt_firewall_public_key }}' > ../etc/dropbear/authorized_keys
+  changed_when: true
 
 - name: Adjust Lan Default to not Bridge
   ansible.builtin.raw: |
@@ -129,6 +141,7 @@
     uci set network.lan.device='eth0'
     uci commit network
     /etc/init.d/network restart
+  changed_when: true
 
 - name: Configure Default wan
   ansible.builtin.raw: |
@@ -145,6 +158,7 @@
     uci add_list firewall.3.network=wan
     uci commit firewall
     /etc/init.d/firewall
+  changed_when: true
   when: mgmt_firewall_default_wan_enabled | default(false)
 
 - name: Configure new LAN interfaces
@@ -164,6 +178,7 @@
     uci commit firewall
     /etc/init.d/firewall restart
 
+  changed_when: true
   loop: "{{ mgmt_firewall_interfaces.mgmt_firewall_lan }}"
 
 - name: Configure DHCP
@@ -183,6 +198,7 @@
     uci commit dhcp
     /etc/init.d/dnsmasq restart
 
+  changed_when: true
   loop: "{{ mgmt_firewall_interfaces.mgmt_firewall_lan }}"
 
 - name: Configure WAN interfaces
@@ -207,6 +223,7 @@
 
     uci commit network
     /etc/init.d/network restart
+  changed_when: true
   loop: "{{ mgmt_firewall_interfaces.mgmt_firewall_wan.interfaces }}"
 
 - name: Apply Port-Forwards
@@ -239,6 +256,7 @@
     {% endif %}
     uci commit firewall
     /etc/init.d/firewall restart
+  changed_when: true
   loop: "{{ mgmt_firewall_port_forwards }}"
 
 - name: Setup Static Routes
@@ -249,6 +267,7 @@
     uci set network.{{ item.network }}.target='0.0.0.0'
     uci set network.{{ item.network }}.gateway='{{ item.gateway }}'
     uci set network.{{ item.network }}.interface='wan'
+  changed_when: true
   loop: "{{ mgmt_firewall_static_routes }}"
   when: mgmt_firewall_static_routes_enabled | default(false)
 
@@ -257,6 +276,7 @@
     uci set network.@switch_vlan[0].ports='0t 4'
     uci set network.@switch_vlan[1].ports='0t 5'
     uci commit network
+  changed_when: true
 
 - name: Setup dynamic VLANs
   ansible.builtin.raw: |
@@ -266,8 +286,10 @@
     uci set network.@switch_vlan[-1].vid='{{ item.vid }}'
     uci set network.@switch_vlan[-1].ports='{{ item.ports }}'
     uci commit network
+  changed_when: true
   loop: "{{ mgmt_firewall_vlans }}"
 
 - name: Restart Network
   ansible.builtin.raw: |
     /etc/init.d/network restart
+  changed_when: true

--- a/partition/roles/mgmt-server/handlers/main.yaml
+++ b/partition/roles/mgmt-server/handlers/main.yaml
@@ -28,10 +28,12 @@
 
 - name: Save iptables v4 rules
   ansible.builtin.shell: iptables-save > /etc/iptables/rules.v4
+  changed_when: true
   listen: Persist iptables
 
 - name: Save iptables v6 rules
   ansible.builtin.shell: ip6tables-save > /etc/iptables/rules.v6
+  changed_when: true
   listen: Persist iptables
 
 - name: Restart sshd

--- a/partition/roles/mgmt-server/tasks/main.yaml
+++ b/partition/roles/mgmt-server/tasks/main.yaml
@@ -176,6 +176,7 @@
   ansible.builtin.meta: flush_handlers
 - name: Flush dhcp routes if we have a bgp session to the firewall
   ansible.builtin.command: ip route flush proto dhcp
+  changed_when: true
   when:
     - mgmt_server_firewall_ip is defined
     - mgmt_server_preserve_dhcp_route is undefined or not mgmt_server_preserve_dhcp_route

--- a/partition/roles/monitoring/gnmic/meta/main.yml
+++ b/partition/roles/monitoring/gnmic/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: metal-stack
-  description: Deploys an image cache to a partition.
+  description: Deploys gnmic for switch telemetry.
   license: MIT
   min_ansible_version: "2.10"
   galaxy_tags: []

--- a/partition/roles/monitoring/prometheus/meta/main.yml
+++ b/partition/roles/monitoring/prometheus/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: prometheus
   author: metal-stack
   description: Deploys prometheus in a systemd-managed Docker container.
   license: MIT

--- a/partition/roles/monitoring/sonic-exporter/meta/main.yml
+++ b/partition/roles/monitoring/sonic-exporter/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: sonic_exporter
   author: metal-stack
   description: "DEPRECATED: Deploys sonic-exporter. Use metal-roles/partition/roles/monitoring/gnmic instead."
   license: MIT

--- a/partition/roles/pixiecore/meta/main.yml
+++ b/partition/roles/pixiecore/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: pixiecore
   author: metal-stack
   description: Deploys the pixecore.
   license: MIT

--- a/partition/roles/promtail/meta/main.yml
+++ b/partition/roles/promtail/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: promtail
   author: metal-stack
   description: "DEPRECATED: Deploys promtail. Use metal-roles/partition/roles/alloy instead."
   license: MIT

--- a/partition/roles/sonic-config/meta/main.yml
+++ b/partition/roles/sonic-config/meta/main.yml
@@ -1,13 +1,12 @@
 ---
 galaxy_info:
-  role_name: sonic-config
   author: metal-stack
   description: This role creates a config_db.json on a SONiC switch, configures the timezone and adds a resolv.conf.
   license: MIT
   min_ansible_version: "2.10"
   galaxy_tags: []
   platforms:
-    - name: SONiC
+    - name: Debian
       versions:
         - all
 

--- a/partition/roles/sonic-config/tasks/generate_config_db.yaml
+++ b/partition/roles/sonic-config/tasks/generate_config_db.yaml
@@ -14,10 +14,12 @@
 - name: Check ntp status
   ansible.builtin.command: show ntp
   register: ntp_status
+  changed_when: false
   failed_when: false
 
 - name: Set time if ntp is not synchronized
   ansible.builtin.command: "date -s '{{ now() }}'"
+  changed_when: true
   when: "'unsynchronised' in ntp_status.stdout"
 
 - name: Run sonic-configdb-utils
@@ -46,6 +48,7 @@
 
 - name: Reload config if reload is required
   ansible.builtin.command: config reload --yes
+  changed_when: true
   async: 120
   poll: 0
   when:
@@ -54,6 +57,7 @@
 
 - name: Load config if not reloaded
   ansible.builtin.command: config load --yes
+  changed_when: true
   when:
     - not sonic_config_reload_config
     - _config_db_json is changed

--- a/partition/roles/sonic-upgrade/meta/main.yml
+++ b/partition/roles/sonic-upgrade/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: sonic
   author: metal-stack
   description: "DEPRECATED: Deploys a SONiC switch."
   license: MIT

--- a/partition/roles/sonic-upgrade/tasks/main.yaml
+++ b/partition/roles/sonic-upgrade/tasks/main.yaml
@@ -15,6 +15,7 @@
 - name: Download the new sonic image
   ansible.builtin.command: ip vrf exec {{ sonic_upgrade_vrf }} wget {{ sonic_upgrade_protocol }}://{{ sonic_upgrade_host }}:{{ sonic_upgrade_port }}/{{
     sonic_upgrade_image }} -O /{{ sonic_upgrade_image }}
+  changed_when: true
   when: sonic_upgrade_host is defined and sonic_upgrade_image_path is not defined
 
 - name: Push the new sonic image to the device
@@ -27,12 +28,14 @@
 
 - name: Install new sonic image
   ansible.builtin.command: "sonic-installer install -y --skip_migration --skip-package-migration /{{ sonic_upgrade_image }}"
+  changed_when: true
 - name: Reboot the system to complete the upgrade
   ansible.builtin.reboot:
 
 - name: Wait until sonic has become ready
   ansible.builtin.command: "show system status"
   register: result
+  changed_when: false
   until: result is not failed
   retries: 30
   delay: 20
@@ -43,3 +46,4 @@
 
 - name: Clean up images
   ansible.builtin.command: sonic-installer cleanup -y
+  changed_when: true

--- a/partition/roles/sonic/handlers/main.yaml
+++ b/partition/roles/sonic/handlers/main.yaml
@@ -6,9 +6,11 @@
 
 - name: Config load
   ansible.builtin.command: config load --yes
+  changed_when: true
 
 - name: Config reload
   ansible.builtin.command: config reload --yes
+  changed_when: true
   async: 120
   poll: 0
   notify: Wait for new connection

--- a/partition/roles/sonic/meta/main.yml
+++ b/partition/roles/sonic/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: sonic-upgrade
   author: metal-stack
   description: Performs an upgrade of the SONiC OS on a device and reboots it to complete the installation.
   license: MIT

--- a/partition/roles/systemd-networkd/handlers/main.yaml
+++ b/partition/roles/systemd-networkd/handlers/main.yaml
@@ -33,6 +33,7 @@
 
 - name: Execute interface rename script
   ansible.builtin.command: /root/rename-interfaces.sh
+  changed_when: true
   async: 300
   poll: 10
   listen: Rename interfaces

--- a/partition/roles/wireguard/tasks/main.yaml
+++ b/partition/roles/wireguard/tasks/main.yaml
@@ -84,6 +84,7 @@
           echo {{ _wg_private_key }} | wg pubkey | tee {{ _public_key_file_path }}
         executable: /bin/bash
       register: _wg_public_key_result
+      changed_when: true
 
     - name: Set public key fact
       ansible.builtin.set_fact:

--- a/partition/roles/ztp/meta/main.yml
+++ b/partition/roles/ztp/meta/main.yml
@@ -1,6 +1,5 @@
 ---
 galaxy_info:
-  role_name: ztp
   author: metal-stack
   description: Configures a server for providing zero-touch-provisioning scripts for switches.
   license: MIT


### PR DESCRIPTION
- add changed_when to all command/shell/raw tasks flagged by no-changed-when, using changed_when: false for read-only commands and changed_when: true for commands that always apply changes
- fix schema[meta] violations: drop the optional role_name field from galaxy_info (it is not used when roles are imported via their directory paths), add a missing description to the top-level meta/main.yml and replace invalid platform entries (SONiC is not a valid galaxy platform)
- add a missing meta/main.yml to the gnmic role so that the setup_yaml action from ansible-common can be resolved (fixes syntax-check[unknown-module])
- remove no-changed-when and schema from the ansible-lint warn_list so they are enforced from now on; role-name and var-naming stay warnings because renaming roles or variables would break downstream consumers
- enable forbid-duplicated-merge-keys in .yamllint (no violations)

#### Used AI-Tools ✨

Claude Fable 5