### PR TITLE
Pin dependencies to commit hashes

### DIFF
--- a/.github/workflows/oci-artifact.yaml
+++ b/.github/workflows/oci-artifact.yaml
@@ -17,10 +17,10 @@ env:
 
 jobs:
   draft:
-    uses: metal-stack/actions-common/.github/workflows/release-drafter.yaml@v1
+    uses: metal-stack/actions-common/.github/workflows/release-drafter.yaml@999a2bd0d754d7b71cd4d4359d20473e78862a4b # v1.0.6
 
   oci-ansible-role:
-    uses: metal-stack/actions-common/.github/workflows/oci-release-vector-artifact.yaml@v1
+    uses: metal-stack/actions-common/.github/workflows/oci-release-vector-artifact.yaml@999a2bd0d754d7b71cd4d4359d20473e78862a4b # v1.0.6
     secrets: inherit
     with:
       artifact-type: ansible-role

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     container: metalstack/metal-deployment-base:latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Test
         run: |
           make test
@@ -16,24 +16,24 @@ jobs:
   spelling:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Check spelling
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0
 
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: markdownlint-cli
-        uses: DavidAnson/markdownlint-cli2-action@main
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
         with:
           globs: "**/*.md"
 
   ansible-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@v26.1.1
+        uses: ansible/ansible-lint@7f6abc5ef97d0fb043a0f3d416dfbc74399fbda0 # v26.1.1
         with:
           requirements_file: requirements.yaml

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,12 +1,40 @@
 ---
 roles:
+  # roles are pinned to commit hashes so that moved or re-created tags
+  # upstream cannot change what gets installed
   - src: https://github.com/metal-stack/ansible-common
+    version: 64a3d304857cea3a749142ca3562a4740d5b0311 # v0.9.0
   - src: https://github.com/metal-stack/metal-ansible-modules
+    version: c1bb6f2193e8ca2e2ac45ebda1c31907bf59af2f # v0.3.2
+  # self-reference to this repository, required so that CI lint can resolve
+  # role paths; must NOT be pinned to a version, otherwise CI would test
+  # against a stale release instead of the current checkout
   - src: https://github.com/metal-stack/metal-roles
 
 collections:
-  - ansible.posix
-  - community.docker
-  - community.general
-  - community.kubernetes
-  - kubernetes.core
+  # collections are installed from their source repositories pinned to commit
+  # hashes instead of from galaxy.ansible.com, so neither a compromised
+  # publisher account nor compromised galaxy infrastructure can change what
+  # gets installed
+  - name: https://github.com/ansible-collections/ansible.posix.git
+    type: git
+    version: e98d9a0756458be1ac710988498000973889075c # 2.2.2
+  - name: https://github.com/ansible-collections/community.docker.git
+    type: git
+    version: a9bb98bc6e64b68ceb056912fdda4fcf13a16a8f # 5.2.1
+  # dependency of community.docker, pinned here so that it is not pulled
+  # from galaxy during dependency resolution
+  - name: https://github.com/ansible-collections/community.library_inventory_filtering.git
+    type: git
+    version: 5f70dd8678885157cb186e8b64382a30cab3e12f # 1.1.5
+  - name: https://github.com/ansible-collections/community.general.git
+    type: git
+    version: 71a3395fa90e854a7465c2bc2c10c12405a803ff # 13.2.0
+  # deprecated, redirects to kubernetes.core; kept and pinned to avoid a
+  # behavior change until usages are migrated
+  - name: https://github.com/ansible-collections/community.kubernetes.git
+    type: git
+    version: 0cc02beb1ecf4c6ad165fe2ee5cf0f9626329766 # 2.0.1
+  - name: https://github.com/ansible-collections/kubernetes.core.git
+    type: git
+    version: 0f472b53e2ee73e11b5f9067ab0826d76183c157 # 6.5.0


### PR DESCRIPTION
We should probably discuss this..

As a security precaution we could consider pinning dependencies like this. Recent hacks (npm) show malicious code injected in dependency projects via the central repository. I guess ansible-galaxy can be hit by such an attack as well.

As a side effect of this no (accidentally) breaking changes by dependency projects are suddenly introduced and we can test every update. Now of course the downside of this is that we'll need to manually bump the version every time a new release is made, ideally after confirming the new release does not contain malicious changes.

#### Used AI-Tools ✨

Claude Fable 5