### PR TITLE
Use boolean jinja2 template overrides

### DIFF
--- a/partition/roles/dhcp/templates/dhcpd.hosts.j2
+++ b/partition/roles/dhcp/templates/dhcpd.hosts.j2
@@ -1,4 +1,4 @@
-#jinja2: lstrip_blocks: "True", trim_blocks: "True"
+#jinja2: lstrip_blocks: True, trim_blocks: True
 {% for host in dhcp_static_hosts %}
 host {{ host.name }} {
   hardware ethernet {{ host.mac }};

--- a/partition/roles/sonic-config/templates/frr.conf.j2
+++ b/partition/roles/sonic-config/templates/frr.conf.j2
@@ -1,4 +1,4 @@
-#jinja2: lstrip_blocks: "True", trim_blocks: "True"
+#jinja2: lstrip_blocks: True, trim_blocks: True
 frr defaults datacenter
 hostname {{ inventory_hostname }}
 !

--- a/partition/roles/sonic/templates/frr.conf.j2
+++ b/partition/roles/sonic/templates/frr.conf.j2
@@ -1,4 +1,4 @@
-#jinja2: lstrip_blocks: "True", trim_blocks: "True"
+#jinja2: lstrip_blocks: True, trim_blocks: True
 frr defaults datacenter
 hostname {{ inventory_hostname }}
 !

--- a/partition/roles/sonic/templates/metal.yaml.j2
+++ b/partition/roles/sonic/templates/metal.yaml.j2
@@ -1,4 +1,4 @@
-#jinja2: lstrip_blocks: "False", trim_blocks: "False"
+#jinja2: lstrip_blocks: True, trim_blocks: True
 ---
 {% set vrfs = [] %}
 DEVICE_METADATA:


### PR DESCRIPTION
ansible-core 2.19 and later reject non-boolean values in the jinja2 override header, so quoted values like "True" fail with 'TemplateOverrides.trim_blocks must be <class bool>'.

On older ansible versions the header value is parsed with ast.literal_eval and the quotes are part of the header text, so "False" yields the string 'False' rather than the boolean. Jinja2 later uses that value in a boolean context, where a non-empty string counts as enabled, which means the metal.yaml.j2 header effectively behaved as True. The headers are therefore set to the literal booleans that match the current rendering behavior, verified against the existing template golden tests.

#### Used AI-Tools ✨

Claude Fable 5