### PR TITLE
Run the test workflow on pull requests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,9 @@ name: Test
 
 on:
   push:
+    branches:
+      - master
+  pull_request:
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The test workflow only triggered on push, so pull requests from forks never ran the test suite in this repository and reviewers had no CI signal on them. Trigger the workflow on pull_request as well and limit the push trigger to master so that branches with an open pull request do not run every job twice. None of the jobs require secrets, so they also work in the restricted context of fork pull requests.
