### PR TITLE
Store s3 request checksum in secret

### DIFF
--- a/control-plane/roles/postgres-backup-restore/templates/postgres.yaml
+++ b/control-plane/roles/postgres-backup-restore/templates/postgres.yaml
@@ -195,6 +195,13 @@ spec:
               key: insecureSkipVerify
               name: backup-restore-sidecar-backup-provider-config-{{ postgres_name }}
 {% endif %}
+{% if postgres_backup_restore_sidecar_s3_request_checksum_calculation %}
+        - name: BACKUP_RESTORE_SIDECAR_S3_REQUEST_CHECKSUM_CALCULATION
+          valueFrom:
+            secretKeyRef:
+              key: requestChecksumCalculation
+              name: backup-restore-sidecar-backup-provider-config-{{ postgres_name }}
+{% endif %}
 {% if postgres_backup_restore_sidecar_s3_trusted_ca_cert %}
         - name: BACKUP_RESTORE_SIDECAR_S3_TRUSTED_CA_CERT
           valueFrom:
@@ -296,9 +303,6 @@ data:
 {% if postgres_backup_restore_sidecar_object_days_max_keep %}
     object-days-max-keep: {{ postgres_backup_restore_sidecar_object_days_max_keep }}
 {% endif %}
-{% if postgres_backup_restore_sidecar_s3_request_checksum_calculation %}
-    s3-request-checksum-calculation: {{ postgres_backup_restore_sidecar_s3_request_checksum_calculation }}
-{% endif %}
     post-exec-cmds:
       - docker-entrypoint.sh postgres {% if postgres_shared_libraries_preload %} -c shared_preload_libraries={{ postgres_shared_libraries_preload | join(',') }}{% endif %}{% if postgres_maintenance_work_mem %} -c maintenance_work_mem={{ postgres_maintenance_work_mem }}{% endif %}{% if postgres_shared_buffers %} -c shared_buffers={{ postgres_shared_buffers }}{% endif %}{% if postgres_effective_cache_size %} -c effective_cache_size={{ postgres_effective_cache_size }}{% endif %}{% if postgres_work_mem %} -c work_mem={{ postgres_work_mem }}{% endif %} -c max_connections={{ postgres_max_connections }}
 ---
@@ -334,6 +338,9 @@ data:
 {% endif %}
 {% if postgres_backup_restore_sidecar_s3_trusted_ca_cert %}
   trustedCaCert: {{ postgres_backup_restore_sidecar_s3_trusted_ca_cert | b64encode }}
+{% endif %}
+{% if postgres_backup_restore_sidecar_s3_request_checksum_calculation %}
+    s3RequestChecksumCalculation: {{ postgres_backup_restore_sidecar_s3_request_checksum_calculation }}
 {% endif %}
 {% endif %}
 {% if postgres_backup_restore_sidecar_encryption_key %}


### PR DESCRIPTION
## Description

Follow-up of #633 
Gardener stores the `s3-request-checksum-calculation` configuration parameter in a `Secret` instead of a `ConfigMap`. We need to decide, if we want to refactor this and do it the same way.

TODO:

- [ ] Implement for rethinkdb as well

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
