### PR TITLE
fix: change default apiserver admin token expiry to 16h

### DIFF
--- a/control-plane/roles/metal/defaults/main.yaml
+++ b/control-plane/roles/metal/defaults/main.yaml
@@ -77,12 +77,12 @@ metal_apiserver_tokens:
   admin_editor_token:
     user: "{{ metal_control_plane_provider_tenant }}"
     tokenCreateRequest:
-      expires: 23040s
+      expires: 57600s
       adminRole: ADMIN_ROLE_EDITOR
   admin_viewer_token:
     user: "{{ metal_control_plane_provider_tenant }}"
     tokenCreateRequest:
-      expires: 23040s
+      expires: 57600s
       adminRole: ADMIN_ROLE_VIEWER
 metal_apiserver_headscale_enabled: false
 metal_apiserver_headscale_tls: true


### PR DESCRIPTION
## Description

The current value of 23040s (6:40h) is too small. The renewal-jobs only runs every 8 hours.